### PR TITLE
Python

### DIFF
--- a/src/python/as_einsum.cxx
+++ b/src/python/as_einsum.cxx
@@ -3,35 +3,55 @@
 using namespace tblis;
 
 static void _as_tensor(tblis_tensor *t, void *data, int dtype, int ndim,
-                       ptrdiff_t *shape, ptrdiff_t *strides)
+                       ptrdiff_t *shape, ptrdiff_t *strides, void *scalar)
 {
-        switch (dtype) {
+    switch (dtype) {
         case TYPE_SINGLE:
+            if (scalar == NULL) {
                 tblis_init_tensor_s(t, ndim, shape, static_cast<float *>(data), strides);
-                break;
+            } else {
+                tblis_init_tensor_scaled_s(t, *(static_cast<float *>(scalar)), ndim, shape,
+                                           static_cast<float *>(data), strides);
+            }
+            break;
         case TYPE_DOUBLE:
+            if (scalar == NULL) {
                 tblis_init_tensor_d(t, ndim, shape, static_cast<double *>(data), strides);
-                break;
+            } else {
+                tblis_init_tensor_scaled_d(t, *(static_cast<double *>(scalar)), ndim, shape,
+                                           static_cast<double *>(data), strides);
+            }
+            break;
         case TYPE_SCOMPLEX:
+            if (scalar == NULL) {
                 tblis_init_tensor_c(t, ndim, shape, static_cast<scomplex *>(data), strides);
-                break;
+            } else {
+                tblis_init_tensor_scaled_c(t, *(static_cast<scomplex *>(scalar)), ndim, shape,
+                                           static_cast<scomplex *>(data), strides);
+            }
+            break;
         case TYPE_DCOMPLEX:
+            if (scalar == NULL) {
                 tblis_init_tensor_z(t, ndim, shape, static_cast<dcomplex *>(data), strides);
-                break;
-        }
+            } else {
+                tblis_init_tensor_scaled_z(t, *(static_cast<dcomplex *>(scalar)), ndim, shape,
+                                           static_cast<dcomplex *>(data), strides);
+            }
+            break;
+    }
 }
 
 extern "C" {
 void as_einsum(void *data_A, int ndim_A, ptrdiff_t *shape_A, ptrdiff_t *strides_A, char *descr_A,
                void *data_B, int ndim_B, ptrdiff_t *shape_B, ptrdiff_t *strides_B, char *descr_B,
                void *data_C, int ndim_C, ptrdiff_t *shape_C, ptrdiff_t *strides_C, char *descr_C,
-               int dtype)
+               int dtype, void *alpha, void *beta)
 {
-        tblis_tensor A, B, C;
-        _as_tensor(&A, data_A, dtype, ndim_A, shape_A, strides_A);
-        _as_tensor(&B, data_B, dtype, ndim_B, shape_B, strides_B);
-        _as_tensor(&C, data_C, dtype, ndim_C, shape_C, strides_C);
+    tblis_tensor A, B, C;
+    _as_tensor(&A, data_A, dtype, ndim_A, shape_A, strides_A, alpha);
+    _as_tensor(&B, data_B, dtype, ndim_B, shape_B, strides_B, NULL);
+    _as_tensor(&C, data_C, dtype, ndim_C, shape_C, strides_C, beta);
 
-        tblis_tensor_mult(NULL, NULL, &A, descr_A, &B, descr_B, &C, descr_C);
+    tblis_tensor_mult(NULL, NULL, &A, descr_A, &B, descr_B, &C, descr_C);
 }
 }

--- a/src/python/tblis_einsum.py
+++ b/src/python/tblis_einsum.py
@@ -126,7 +126,8 @@ def einsum(subscripts, *tensors, **kwargs):
         out = _contract(subscripts, *tensors, **kwargs)
     else:
         sub_idx = subscripts.split(',', 2)
-        res_idx = ''.join(set(sub_idx[0]).symmetric_difference(sub_idx[1]))
+        res_idx = ''.join(set(sub_idx[0]+sub_idx[1]).intersection(sub_idx[2]))
+        res_idx = res_idx.replace(',','')
         script0 = sub_idx[0] + ',' + sub_idx[1] + '->' + res_idx
         subscripts = res_idx + ',' + sub_idx[2]
         tensors = [_contract(script0, *tensors[:2])] + list(tensors[2:])

--- a/test/test_tblis_einsum.py
+++ b/test/test_tblis_einsum.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy
 import tblis_einsum
-from tblis_einsum import einsum
+einsum = tblis_einsum.einsum
 
 class KnownValues(unittest.TestCase):
     def test_d_d(self):
@@ -114,6 +114,15 @@ class KnownValues(unittest.TestCase):
         c = numpy.random.random((2,8,3,6))
         c0 = numpy.einsum('abcd,fdea,ficj->iebj', a, b, c)
         c1 = einsum('abcd,fdea,ficj->iebj', a, b, c)
+        self.assertTrue(c0.dtype == c1.dtype)
+        self.assertTrue(abs(c0-c1).max() < 1e-13)
+
+    def test_3operands1(self):
+        a = numpy.random.random((2,2,2,2)) + 1j
+        b = numpy.random.random((2,2,2,2))
+        c = numpy.random.random((2,2,2,2))
+        c0 = numpy.einsum('abcd,acde,adef->ebf', a, b, c)
+        c1 = einsum('abcd,acde,adef->ebf', a, b, c)
         self.assertTrue(c0.dtype == c1.dtype)
         self.assertTrue(abs(c0-c1).max() < 1e-13)
 

--- a/test/test_tblis_einsum.py
+++ b/test/test_tblis_einsum.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy
+import tblis_einsum
 from tblis_einsum import einsum
 
 class KnownValues(unittest.TestCase):
@@ -153,6 +154,16 @@ class KnownValues(unittest.TestCase):
         b = numpy.random.random((2,4,7))
         c0 = numpy.einsum('...jkj,jlp->...jp', a, b)
         c1 = einsum('...jkj,jlp->...jp', a, b)
+        self.assertTrue(abs(c0-c1).max() < 1e-13)
+
+    def test_contract(self):
+        a = numpy.random.random((5,4,6))
+        b = numpy.random.random((4,9,6))
+
+        c1 = numpy.ones((9,5), dtype=numpy.complex128)
+        c0 = tblis_einsum._contract('ijk,jlk->li', a, b, out=c1, alpha=.5j, beta=.2)
+        c1 = numpy.ones((9,5), dtype=numpy.complex128)
+        c1 = c1*.2 + numpy.einsum('ijk,jlk->li', a, b)*.5j
         self.assertTrue(abs(c0-c1).max() < 1e-13)
 
 


### PR DESCRIPTION
Fix a bug in tblis-einsum interface when repeated indices are presented in the contraction over 3 operands.