### PR TITLE
SYSCTL -> SYSCTLBYNAME

### DIFF
--- a/src/util/thread.cxx
+++ b/src/util/thread.cxx
@@ -66,7 +66,7 @@ struct thread_configuration
 
             num_threads = strtol(s.c_str(), NULL, 10);
 
-            #elif TBLIS_HAVE_SYSCTL
+            #elif TBLIS_HAVE_SYSCTLBYNAME
 
             size_t len = sizeof(num_threads);
             sysctlbyname("hw.physicalcpu", &num_threads, &len, NULL, 0);


### PR DESCRIPTION
Change `TBLIS_HAVE_SYSCTL` to `TBLIS_HAVE_SYSCTLBYNAME` to avoid calling `sysctlbyname` in non-Darwin/BSD environments. 