### PR TITLE
SkylakeX CPU Detect Supports Gen2 & Gen3.

### DIFF
--- a/src/configs/skx2/vpu_count.cxx
+++ b/src/configs/skx2/vpu_count.cxx
@@ -73,7 +73,18 @@ int vpu_count()
         loc = name.find_first_of("- ", loc+1)+1;
 
         auto sku = atoi(name.substr(loc, 4).c_str());
-        if      (8199 >= sku && sku >= 8100) return 2;
+        if      (8399 >= sku && sku >= 8300) return 2; // Gen 3.
+        else if (6399 >= sku && sku >= 6300) return 2;
+        else if (5399 >= sku && sku >= 5300) return 2;
+        else if (4399 >= sku && sku >= 4300) return 2;
+        else if (9299 >= sku && sku >= 9200) return 2; // Gen 2.
+        else if (8299 >= sku && sku >= 8200) return 2;
+        else if (6299 >= sku && sku >= 6200) return 2;
+        else if (sku == 5222)                return 2;
+        else if (5299 >= sku && sku >= 5200) return 1;
+        else if (4299 >= sku && sku >= 4200) return 1;
+        else if (3299 >= sku && sku >= 3200) return 1;
+        else if (8199 >= sku && sku >= 8100) return 2; // Gen 1.
         else if (6199 >= sku && sku >= 6100) return 2;
         else if (sku == 5122)                return 2;
         else if (5199 >= sku && sku >= 5100) return 1;


### PR DESCRIPTION
It seems that only Gen1 SkylakeX is recognized by current `skx2` config.

To support later Gen2 & Gen3 CPUs, additional lines in VPU counter seems required.