### PR TITLE
Arm Kernels & Configurations

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -357,25 +357,16 @@ endif
 # ARM architectures
 # 
     
-#if ENABLE_ARMV7A
-#noinst_LTLIBRARIES += lib/libarmv7a.la
-#lib_libtblis_la_LIBADD += lib/libarmv7a.la
-#lib_libarmv7a_la_SOURCES = src/external/blis/config/armv7a/kernels/3/bli_cgemm_kernel_2x2.S \
-#                           src/external/blis/config/armv7a/kernels/3/bli_dgemm_kernel_4x4.S \
-#                           src/external/blis/config/armv7a/kernels/3/bli_sgemm_kernel_4x4.S \
-#                           src/external/blis/config/armv7a/kernels/3/bli_zgemm_kernel_2x2.S \
-#                           src/external/blis/config/armv7a/kernels/3/bli_gemm_opt_4x4.c
-#lib_libarmv7a_la_CCASFLAGS = -mfloat-abi=hard -mfpu=vfpv3 -marm -march=armv7-a
-#lib_libarmv7a_la_CFLAGS = -Isrc/external/blis/config/armv7a -mfloat-abi=hard -mfpu=vfpv3 -marm -march=armv7-a
-#endif
-#
-#if ENABLE_ARMV8A
-#noinst_LTLIBRARIES += lib/libarmv8a.la
-#lib_libtblis_la_LIBADD += lib/libarmv8a.la
-#lib_libarmv8a_la_SOURCES = src/external/blis/config/armv8a/kernels/3/bli_gemm_opt_4x4.c
-#lib_libarmv8a_la_CFLAGS = -Isrc/external/blis/config/armv8a -march=armv8-a+fp+simd -mcpu=cortex-a57.cortex-a53
-#endif
-#
+if ENABLE_ARMV7A
+noinst_LTLIBRARIES += lib/libarmv7a.la
+lib_libtblis_la_LIBADD += lib/libarmv7a.la
+lib_libtblis_la_SOURCES += src/configs/armv7a/config.cxx
+lib_libarmv7a_la_SOURCES = src/configs/armv7a/config_ker.cxx \
+                           src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c
+lib_libarmv7a_la_CCASFLAGS = -mfloat-abi=hard -mfpu=vfpv3 -marm -march=armv7-a
+lib_libarmv7a_la_CFLAGS = -mfloat-abi=hard -mfpu=vfpv3 -marm -march=armv7-a
+endif
+
 #if ENABLE_CORTEX_A15
 #noinst_LTLIBRARIES += lib/libcortex-a15.la
 #lib_libtblis_la_LIBADD += lib/libcortex-a15.la
@@ -389,6 +380,26 @@ endif
 #lib_libcortex_a9_la_SOURCES = src/external/blis/config/cortex-a9/kernels/3/bli_gemm_opt_4x4.c
 #lib_libcortex_a9_la_CFLAGS = -Isrc/external/blis/config/cortex-a9 -mfloat-abi=hard -mfpu=neon -march=armv7-a
 #endif
+
+if ENABLE_ARMV8A
+noinst_LTLIBRARIES += lib/libarmv8a.la
+lib_libtblis_la_LIBADD += lib/libarmv8a.la
+lib_libtblis_la_SOURCES += src/configs/armv8a/config.cxx
+lib_libarmv8a_la_SOURCES = src/configs/armv8a/config_ker.cxx \
+                           src/configs/armv8a/bli_gemm_asm_d6x8.c
+lib_libarmv8a_la_CFLAGS = -march=armv8-a+fp+simd
+endif
+
+if ENABLE_THUNDERX2
+noinst_LTLIBRARIES += lib/libthunderx2.la
+lib_libtblis_la_LIBADD += lib/libthunderx2.la
+lib_libtblis_la_SOURCES += src/configs/thunderx2/config.cxx
+lib_libthunderx2_la_SOURCES = src/configs/thunderx2/config_ker.cxx
+if !ENABLE_ARMV8A
+lib_libthunderx2_la_SOURCES += src/configs/armv8a/bli_gemm_asm_d6x8.c
+endif
+lib_libthunderx2_la_CFLAGS = -march=armv8-a+fp+simd -mcpu=thunderx2t99
+endif
 
 #
 # IBM architectures

--- a/Makefile.in
+++ b/Makefile.in
@@ -136,11 +136,47 @@ host_triplet = @host@
 @ENABLE_SKX2_TRUE@am__append_37 = src/configs/skx2/vpu_count.cxx \
 @ENABLE_SKX2_TRUE@                           src/configs/skx2/config.cxx
 
+
+#if ENABLE_MIC
+#noinst_LTLIBRARIES += lib/libmic.la
+#lib_libtblis_la_LIBADD += lib/libmic.la
+#lib_libmic_la_SOURCES = src/external/blis/config/mic/kernels/3/bli_dgemm_opt_30x8.c \
+#                         src/external/blis/config/mic/kernels/3/bli_sgemm_opt_30x16.c
+#lib_libmic_la_CFLAGS = -Isrc/external/blis/config/mic -fasm-blocks
+#endif
+
+#
+# ARM architectures
+# 
+@ENABLE_ARMV7A_TRUE@am__append_38 = lib/libarmv7a.la
+@ENABLE_ARMV7A_TRUE@am__append_39 = lib/libarmv7a.la
+@ENABLE_ARMV7A_TRUE@am__append_40 = src/configs/armv7a/config.cxx
+
+#if ENABLE_CORTEX_A15
+#noinst_LTLIBRARIES += lib/libcortex-a15.la
+#lib_libtblis_la_LIBADD += lib/libcortex-a15.la
+#lib_libcortex_a15_la_SOURCES = src/external/blis/config/cortex-a15/kernels/3/bli_gemm_opt_4x4.c
+#lib_libcortex_a15_la_CFLAGS = -Isrc/external/blis/config/cortex-a15 -mfloat-abi=hard -mfpu=neon -march=armv7-a
+#endif
+#
+#if ENABLE_CORTEX_A9
+#noinst_LTLIBRARIES += lib/libcortex-a9.la
+#lib_libtblis_la_LIBADD += lib/libcortex-a9.la
+#lib_libcortex_a9_la_SOURCES = src/external/blis/config/cortex-a9/kernels/3/bli_gemm_opt_4x4.c
+#lib_libcortex_a9_la_CFLAGS = -Isrc/external/blis/config/cortex-a9 -mfloat-abi=hard -mfpu=neon -march=armv7-a
+#endif
+@ENABLE_ARMV8A_TRUE@am__append_41 = lib/libarmv8a.la
+@ENABLE_ARMV8A_TRUE@am__append_42 = lib/libarmv8a.la
+@ENABLE_ARMV8A_TRUE@am__append_43 = src/configs/armv8a/config.cxx
+@ENABLE_THUNDERX2_TRUE@am__append_44 = lib/libthunderx2.la
+@ENABLE_THUNDERX2_TRUE@am__append_45 = lib/libthunderx2.la
+@ENABLE_THUNDERX2_TRUE@am__append_46 = src/configs/thunderx2/config.cxx
+@ENABLE_ARMV8A_FALSE@@ENABLE_THUNDERX2_TRUE@am__append_47 = src/configs/armv8a/bli_gemm_asm_d6x8.c
 noinst_PROGRAMS = bin/test$(EXEEXT) $(am__EXEEXT_1) $(am__EXEEXT_2) \
 	$(am__EXEEXT_3)
-@ENABLE_BLAS_TRUE@am__append_38 = bin/bench bin/batched_bench #bin/dpd_bench
-@ENABLE_BLAS_TRUE@@ENABLE_SKX1_TRUE@am__append_39 = bin/skx_bench
-@ENABLE_BLAS_TRUE@@ENABLE_SKX1_FALSE@@ENABLE_SKX2_TRUE@am__append_40 = bin/skx_bench
+@ENABLE_BLAS_TRUE@am__append_48 = bin/bench bin/batched_bench #bin/dpd_bench
+@ENABLE_BLAS_TRUE@@ENABLE_SKX1_TRUE@am__append_49 = bin/skx_bench
+@ENABLE_BLAS_TRUE@@ENABLE_SKX1_FALSE@@ENABLE_SKX2_TRUE@am__append_50 = bin/skx_bench
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/as-gcc-inline-assembly.m4 \
@@ -211,18 +247,34 @@ am__installdirs = "$(DESTDIR)$(libdir)" \
 	"$(DESTDIR)$(memoryincludedir)" "$(DESTDIR)$(pkgincludedir)" \
 	"$(DESTDIR)$(stl_extincludedir)" "$(DESTDIR)$(utilincludedir)"
 LTLIBRARIES = $(lib_LTLIBRARIES) $(noinst_LTLIBRARIES)
-lib_libbulldozer_la_LIBADD =
-am__lib_libbulldozer_la_SOURCES_DIST =  \
-	src/configs/bulldozer/bli_gemm_asm_d4x6_fma4.c \
-	src/configs/bulldozer/config_ker.cxx
+lib_libarmv7a_la_LIBADD =
+am__lib_libarmv7a_la_SOURCES_DIST = src/configs/armv7a/config_ker.cxx \
+	src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c
 am__dirstamp = $(am__leading_dot)dirstamp
-@ENABLE_BULLDOZER_TRUE@am_lib_libbulldozer_la_OBJECTS = src/configs/bulldozer/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.lo \
-@ENABLE_BULLDOZER_TRUE@	src/configs/bulldozer/lib_libbulldozer_la-config_ker.lo
-lib_libbulldozer_la_OBJECTS = $(am_lib_libbulldozer_la_OBJECTS)
+@ENABLE_ARMV7A_TRUE@am_lib_libarmv7a_la_OBJECTS =  \
+@ENABLE_ARMV7A_TRUE@	src/configs/armv7a/config_ker.lo \
+@ENABLE_ARMV7A_TRUE@	src/configs/armv7a/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.lo
+lib_libarmv7a_la_OBJECTS = $(am_lib_libarmv7a_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
+@ENABLE_ARMV7A_TRUE@am_lib_libarmv7a_la_rpath =
+lib_libarmv8a_la_LIBADD =
+am__lib_libarmv8a_la_SOURCES_DIST = src/configs/armv8a/config_ker.cxx \
+	src/configs/armv8a/bli_gemm_asm_d6x8.c
+@ENABLE_ARMV8A_TRUE@am_lib_libarmv8a_la_OBJECTS =  \
+@ENABLE_ARMV8A_TRUE@	src/configs/armv8a/config_ker.lo \
+@ENABLE_ARMV8A_TRUE@	src/configs/armv8a/lib_libarmv8a_la-bli_gemm_asm_d6x8.lo
+lib_libarmv8a_la_OBJECTS = $(am_lib_libarmv8a_la_OBJECTS)
+@ENABLE_ARMV8A_TRUE@am_lib_libarmv8a_la_rpath =
+lib_libbulldozer_la_LIBADD =
+am__lib_libbulldozer_la_SOURCES_DIST =  \
+	src/configs/bulldozer/bli_gemm_asm_d4x6_fma4.c \
+	src/configs/bulldozer/config_ker.cxx
+@ENABLE_BULLDOZER_TRUE@am_lib_libbulldozer_la_OBJECTS = src/configs/bulldozer/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.lo \
+@ENABLE_BULLDOZER_TRUE@	src/configs/bulldozer/lib_libbulldozer_la-config_ker.lo
+lib_libbulldozer_la_OBJECTS = $(am_lib_libbulldozer_la_OBJECTS)
 lib_libbulldozer_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(lib_libbulldozer_la_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
@@ -349,7 +401,8 @@ lib_libtblis_la_DEPENDENCIES = src/external/tci/lib/libtci.la \
 	$(am__append_3) $(am__append_5) $(am__append_8) \
 	$(am__append_11) $(am__append_15) $(am__append_19) \
 	$(am__append_22) $(am__append_25) $(am__append_28) \
-	$(am__append_31) $(am__append_36)
+	$(am__append_31) $(am__append_36) $(am__append_39) \
+	$(am__append_42) $(am__append_45)
 am__lib_libtblis_la_SOURCES_DIST = src/iface/1t/add.cxx \
 	src/iface/1t/dot.cxx src/iface/1t/reduce.cxx \
 	src/iface/1t/scale.cxx src/iface/1t/set.cxx \
@@ -386,7 +439,8 @@ am__lib_libtblis_la_SOURCES_DIST = src/iface/1t/add.cxx \
 	src/configs/sandybridge/config.cxx \
 	src/configs/haswell/config.cxx src/configs/knl/config.cxx \
 	src/configs/skx1/config.cxx src/configs/skx2/vpu_count.cxx \
-	src/configs/skx2/config.cxx
+	src/configs/skx2/config.cxx src/configs/armv7a/config.cxx \
+	src/configs/armv8a/config.cxx src/configs/thunderx2/config.cxx
 @ENABLE_BULLDOZER_TRUE@am__objects_3 =  \
 @ENABLE_BULLDOZER_TRUE@	src/configs/bulldozer/config.lo
 @ENABLE_PILEDRIVER_TRUE@am__objects_4 =  \
@@ -403,6 +457,10 @@ am__lib_libtblis_la_SOURCES_DIST = src/iface/1t/add.cxx \
 @ENABLE_SKX1_TRUE@@ENABLE_SKX2_FALSE@am__objects_12 = src/configs/skx2/vpu_count.lo
 @ENABLE_SKX2_TRUE@am__objects_13 = src/configs/skx2/vpu_count.lo \
 @ENABLE_SKX2_TRUE@	src/configs/skx2/config.lo
+@ENABLE_ARMV7A_TRUE@am__objects_14 = src/configs/armv7a/config.lo
+@ENABLE_ARMV8A_TRUE@am__objects_15 = src/configs/armv8a/config.lo
+@ENABLE_THUNDERX2_TRUE@am__objects_16 =  \
+@ENABLE_THUNDERX2_TRUE@	src/configs/thunderx2/config.lo
 am_lib_libtblis_la_OBJECTS = src/iface/1t/add.lo src/iface/1t/dot.lo \
 	src/iface/1t/reduce.lo src/iface/1t/scale.lo \
 	src/iface/1t/set.lo src/iface/1t/shift.lo src/iface/3t/mult.lo \
@@ -434,15 +492,26 @@ am_lib_libtblis_la_OBJECTS = src/iface/1t/add.lo src/iface/1t/dot.lo \
 	$(am__objects_4) $(am__objects_5) $(am__objects_6) \
 	$(am__objects_7) $(am__objects_8) $(am__objects_9) \
 	$(am__objects_10) $(am__objects_11) $(am__objects_12) \
-	$(am__objects_13)
+	$(am__objects_13) $(am__objects_14) $(am__objects_15) \
+	$(am__objects_16)
 lib_libtblis_la_OBJECTS = $(am_lib_libtblis_la_OBJECTS)
+lib_libthunderx2_la_LIBADD =
+am__lib_libthunderx2_la_SOURCES_DIST =  \
+	src/configs/thunderx2/config_ker.cxx \
+	src/configs/armv8a/bli_gemm_asm_d6x8.c
+@ENABLE_ARMV8A_FALSE@@ENABLE_THUNDERX2_TRUE@am__objects_17 = src/configs/armv8a/lib_libthunderx2_la-bli_gemm_asm_d6x8.lo
+@ENABLE_THUNDERX2_TRUE@am_lib_libthunderx2_la_OBJECTS =  \
+@ENABLE_THUNDERX2_TRUE@	src/configs/thunderx2/config_ker.lo \
+@ENABLE_THUNDERX2_TRUE@	$(am__objects_17)
+lib_libthunderx2_la_OBJECTS = $(am_lib_libthunderx2_la_OBJECTS)
+@ENABLE_THUNDERX2_TRUE@am_lib_libthunderx2_la_rpath =
 lib_libzen_la_LIBADD =
 am__lib_libzen_la_SOURCES_DIST = src/configs/zen/config_ker.cxx \
 	src/configs/haswell/bli_gemm_asm_d6x8.c
-@ENABLE_HASWELL_FALSE@@ENABLE_ZEN_TRUE@am__objects_14 = src/configs/haswell/lib_libzen_la-bli_gemm_asm_d6x8.lo
+@ENABLE_HASWELL_FALSE@@ENABLE_ZEN_TRUE@am__objects_18 = src/configs/haswell/lib_libzen_la-bli_gemm_asm_d6x8.lo
 @ENABLE_ZEN_TRUE@am_lib_libzen_la_OBJECTS =  \
 @ENABLE_ZEN_TRUE@	src/configs/zen/lib_libzen_la-config_ker.lo \
-@ENABLE_ZEN_TRUE@	$(am__objects_14)
+@ENABLE_ZEN_TRUE@	$(am__objects_18)
 lib_libzen_la_OBJECTS = $(am_lib_libzen_la_OBJECTS)
 lib_libzen_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
@@ -485,6 +554,13 @@ DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp = $(SHELL) $(top_srcdir)/depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = src/configs/$(DEPDIR)/configs.Plo \
+	src/configs/armv7a/$(DEPDIR)/config.Plo \
+	src/configs/armv7a/$(DEPDIR)/config_ker.Plo \
+	src/configs/armv7a/$(DEPDIR)/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.Plo \
+	src/configs/armv8a/$(DEPDIR)/config.Plo \
+	src/configs/armv8a/$(DEPDIR)/config_ker.Plo \
+	src/configs/armv8a/$(DEPDIR)/lib_libarmv8a_la-bli_gemm_asm_d6x8.Plo \
+	src/configs/armv8a/$(DEPDIR)/lib_libthunderx2_la-bli_gemm_asm_d6x8.Plo \
 	src/configs/bulldozer/$(DEPDIR)/config.Plo \
 	src/configs/bulldozer/$(DEPDIR)/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.Plo \
 	src/configs/bulldozer/$(DEPDIR)/lib_libbulldozer_la-config_ker.Plo \
@@ -520,6 +596,8 @@ am__depfiles_remade = src/configs/$(DEPDIR)/configs.Plo \
 	src/configs/skx2/$(DEPDIR)/lib_libskx2_la-bli_sgemm_opt_12x32_l2.Plo \
 	src/configs/skx2/$(DEPDIR)/lib_libskx2_la-config_ker.Plo \
 	src/configs/skx2/$(DEPDIR)/vpu_count.Plo \
+	src/configs/thunderx2/$(DEPDIR)/config.Plo \
+	src/configs/thunderx2/$(DEPDIR)/config_ker.Plo \
 	src/configs/zen/$(DEPDIR)/config.Plo \
 	src/configs/zen/$(DEPDIR)/lib_libzen_la-config_ker.Plo \
 	src/iface/1t/$(DEPDIR)/add.Plo src/iface/1t/$(DEPDIR)/dot.Plo \
@@ -609,16 +687,19 @@ AM_V_CXXLD = $(am__v_CXXLD_@AM_V@)
 am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
 am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
-SOURCES = $(lib_libbulldozer_la_SOURCES) $(lib_libcore2_la_SOURCES) \
+SOURCES = $(lib_libarmv7a_la_SOURCES) $(lib_libarmv8a_la_SOURCES) \
+	$(lib_libbulldozer_la_SOURCES) $(lib_libcore2_la_SOURCES) \
 	$(lib_libexcavator_la_SOURCES) $(lib_libhaswell_la_SOURCES) \
 	$(lib_libknl_la_SOURCES) $(lib_libpiledriver_la_SOURCES) \
 	$(lib_libreference_la_SOURCES) \
 	$(lib_libsandybridge_la_SOURCES) $(lib_libskx1_la_SOURCES) \
 	$(lib_libskx2_la_SOURCES) $(lib_libtblis_la_SOURCES) \
-	$(lib_libzen_la_SOURCES) $(bin_batched_bench_SOURCES) \
-	$(bin_bench_SOURCES) $(bin_skx_bench_SOURCES) \
-	$(bin_test_SOURCES)
-DIST_SOURCES = $(am__lib_libbulldozer_la_SOURCES_DIST) \
+	$(lib_libthunderx2_la_SOURCES) $(lib_libzen_la_SOURCES) \
+	$(bin_batched_bench_SOURCES) $(bin_bench_SOURCES) \
+	$(bin_skx_bench_SOURCES) $(bin_test_SOURCES)
+DIST_SOURCES = $(am__lib_libarmv7a_la_SOURCES_DIST) \
+	$(am__lib_libarmv8a_la_SOURCES_DIST) \
+	$(am__lib_libbulldozer_la_SOURCES_DIST) \
 	$(am__lib_libcore2_la_SOURCES_DIST) \
 	$(am__lib_libexcavator_la_SOURCES_DIST) \
 	$(am__lib_libhaswell_la_SOURCES_DIST) \
@@ -629,6 +710,7 @@ DIST_SOURCES = $(am__lib_libbulldozer_la_SOURCES_DIST) \
 	$(am__lib_libskx1_la_SOURCES_DIST) \
 	$(am__lib_libskx2_la_SOURCES_DIST) \
 	$(am__lib_libtblis_la_SOURCES_DIST) \
+	$(am__lib_libthunderx2_la_SOURCES_DIST) \
 	$(am__lib_libzen_la_SOURCES_DIST) $(bin_batched_bench_SOURCES) \
 	$(bin_bench_SOURCES) $(bin_skx_bench_SOURCES) \
 	$(bin_test_SOURCES)
@@ -891,7 +973,8 @@ lib_libtblis_la_SOURCES = src/iface/1t/add.cxx src/iface/1t/dot.cxx \
 	$(am__append_9) $(am__append_12) $(am__append_16) \
 	$(am__append_20) $(am__append_23) $(am__append_26) \
 	$(am__append_29) $(am__append_32) $(am__append_33) \
-	$(am__append_37)
+	$(am__append_37) $(am__append_40) $(am__append_43) \
+	$(am__append_46)
 pkginclude_HEADERS = src/tblis.h src/tblis_config.h
 utilincludedir = $(pkgincludedir)/util
 utilinclude_HEADERS = \
@@ -980,12 +1063,14 @@ stl_extinclude_HEADERS = \
 noinst_LTLIBRARIES = $(am__append_2) $(am__append_4) $(am__append_7) \
 	$(am__append_10) $(am__append_14) $(am__append_18) \
 	$(am__append_21) $(am__append_24) $(am__append_27) \
-	$(am__append_30) $(am__append_35)
+	$(am__append_30) $(am__append_35) $(am__append_38) \
+	$(am__append_41) $(am__append_44)
 lib_libtblis_la_LIBADD = src/external/tci/lib/libtci.la \
 	$(am__append_3) $(am__append_5) $(am__append_8) \
 	$(am__append_11) $(am__append_15) $(am__append_19) \
 	$(am__append_22) $(am__append_25) $(am__append_28) \
-	$(am__append_31) $(am__append_36)
+	$(am__append_31) $(am__append_36) $(am__append_39) \
+	$(am__append_42) $(am__append_45)
 @ENABLE_REFERENCE_TRUE@lib_libreference_la_SOURCES = src/configs/reference/config.cxx
 @ENABLE_REFERENCE_TRUE@lib_libreference_la_CFLAGS = -O3
 @ENABLE_REFERENCE_TRUE@lib_libreference_la_CXXFLAGS = -O3
@@ -1078,6 +1163,19 @@ lib_libtblis_la_LIBADD = src/external/tci/lib/libtci.la \
 @ENABLE_INTEL_COMPILER_FALSE@@ENABLE_SKX2_TRUE@@IS_OSX_FALSE@lib_libskx2_la_CXXFLAGS = -O3 -mavx512f -mavx512dq -mavx512bw -mavx512vl -march=skylake-avx512 -mfpmath=sse
 @ENABLE_INTEL_COMPILER_FALSE@@ENABLE_SKX2_TRUE@@IS_OSX_TRUE@lib_libskx2_la_CXXFLAGS = -O3 -mavx512f -mavx512dq -mavx512bw -mavx512vl -march=skylake-avx512 -mfpmath=sse -Wa,-march=skylake-avx512
 @ENABLE_INTEL_COMPILER_TRUE@@ENABLE_SKX2_TRUE@lib_libskx2_la_CXXFLAGS = -O3 -xCORE-AVX512
+@ENABLE_ARMV7A_TRUE@lib_libarmv7a_la_SOURCES = src/configs/armv7a/config_ker.cxx \
+@ENABLE_ARMV7A_TRUE@                           src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c
+
+@ENABLE_ARMV7A_TRUE@lib_libarmv7a_la_CCASFLAGS = -mfloat-abi=hard -mfpu=vfpv3 -marm -march=armv7-a
+@ENABLE_ARMV7A_TRUE@lib_libarmv7a_la_CFLAGS = -mfloat-abi=hard -mfpu=vfpv3 -marm -march=armv7-a
+@ENABLE_ARMV8A_TRUE@lib_libarmv8a_la_SOURCES = src/configs/armv8a/config_ker.cxx \
+@ENABLE_ARMV8A_TRUE@                           src/configs/armv8a/bli_gemm_asm_d6x8.c
+
+@ENABLE_ARMV8A_TRUE@lib_libarmv8a_la_CFLAGS = -march=armv8-a+fp+simd
+@ENABLE_THUNDERX2_TRUE@lib_libthunderx2_la_SOURCES =  \
+@ENABLE_THUNDERX2_TRUE@	src/configs/thunderx2/config_ker.cxx \
+@ENABLE_THUNDERX2_TRUE@	$(am__append_47)
+@ENABLE_THUNDERX2_TRUE@lib_libthunderx2_la_CFLAGS = -march=armv8-a+fp+simd -mcpu=thunderx2t99
 bin_test_SOURCES = test/test.cxx \
                    \
                    test/1t/dot.cxx \
@@ -1227,6 +1325,37 @@ clean-noinstLTLIBRARIES:
 	  echo rm -f $${locs}; \
 	  rm -f $${locs}; \
 	}
+src/configs/armv7a/$(am__dirstamp):
+	@$(MKDIR_P) src/configs/armv7a
+	@: > src/configs/armv7a/$(am__dirstamp)
+src/configs/armv7a/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) src/configs/armv7a/$(DEPDIR)
+	@: > src/configs/armv7a/$(DEPDIR)/$(am__dirstamp)
+src/configs/armv7a/config_ker.lo: src/configs/armv7a/$(am__dirstamp) \
+	src/configs/armv7a/$(DEPDIR)/$(am__dirstamp)
+src/configs/armv7a/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.lo:  \
+	src/configs/armv7a/$(am__dirstamp) \
+	src/configs/armv7a/$(DEPDIR)/$(am__dirstamp)
+lib/$(am__dirstamp):
+	@$(MKDIR_P) lib
+	@: > lib/$(am__dirstamp)
+
+lib/libarmv7a.la: $(lib_libarmv7a_la_OBJECTS) $(lib_libarmv7a_la_DEPENDENCIES) $(EXTRA_lib_libarmv7a_la_DEPENDENCIES) lib/$(am__dirstamp)
+	$(AM_V_CXXLD)$(CXXLINK) $(am_lib_libarmv7a_la_rpath) $(lib_libarmv7a_la_OBJECTS) $(lib_libarmv7a_la_LIBADD) $(LIBS)
+src/configs/armv8a/$(am__dirstamp):
+	@$(MKDIR_P) src/configs/armv8a
+	@: > src/configs/armv8a/$(am__dirstamp)
+src/configs/armv8a/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) src/configs/armv8a/$(DEPDIR)
+	@: > src/configs/armv8a/$(DEPDIR)/$(am__dirstamp)
+src/configs/armv8a/config_ker.lo: src/configs/armv8a/$(am__dirstamp) \
+	src/configs/armv8a/$(DEPDIR)/$(am__dirstamp)
+src/configs/armv8a/lib_libarmv8a_la-bli_gemm_asm_d6x8.lo:  \
+	src/configs/armv8a/$(am__dirstamp) \
+	src/configs/armv8a/$(DEPDIR)/$(am__dirstamp)
+
+lib/libarmv8a.la: $(lib_libarmv8a_la_OBJECTS) $(lib_libarmv8a_la_DEPENDENCIES) $(EXTRA_lib_libarmv8a_la_DEPENDENCIES) lib/$(am__dirstamp)
+	$(AM_V_CXXLD)$(CXXLINK) $(am_lib_libarmv8a_la_rpath) $(lib_libarmv8a_la_OBJECTS) $(lib_libarmv8a_la_LIBADD) $(LIBS)
 src/configs/bulldozer/$(am__dirstamp):
 	@$(MKDIR_P) src/configs/bulldozer
 	@: > src/configs/bulldozer/$(am__dirstamp)
@@ -1239,9 +1368,6 @@ src/configs/bulldozer/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.lo:  \
 src/configs/bulldozer/lib_libbulldozer_la-config_ker.lo:  \
 	src/configs/bulldozer/$(am__dirstamp) \
 	src/configs/bulldozer/$(DEPDIR)/$(am__dirstamp)
-lib/$(am__dirstamp):
-	@$(MKDIR_P) lib
-	@: > lib/$(am__dirstamp)
 
 lib/libbulldozer.la: $(lib_libbulldozer_la_OBJECTS) $(lib_libbulldozer_la_DEPENDENCIES) $(EXTRA_lib_libbulldozer_la_DEPENDENCIES) lib/$(am__dirstamp)
 	$(AM_V_CXXLD)$(lib_libbulldozer_la_LINK) $(am_lib_libbulldozer_la_rpath) $(lib_libbulldozer_la_OBJECTS) $(lib_libbulldozer_la_LIBADD) $(LIBS)
@@ -1609,9 +1735,31 @@ src/configs/skx2/vpu_count.lo: src/configs/skx2/$(am__dirstamp) \
 	src/configs/skx2/$(DEPDIR)/$(am__dirstamp)
 src/configs/skx2/config.lo: src/configs/skx2/$(am__dirstamp) \
 	src/configs/skx2/$(DEPDIR)/$(am__dirstamp)
+src/configs/armv7a/config.lo: src/configs/armv7a/$(am__dirstamp) \
+	src/configs/armv7a/$(DEPDIR)/$(am__dirstamp)
+src/configs/armv8a/config.lo: src/configs/armv8a/$(am__dirstamp) \
+	src/configs/armv8a/$(DEPDIR)/$(am__dirstamp)
+src/configs/thunderx2/$(am__dirstamp):
+	@$(MKDIR_P) src/configs/thunderx2
+	@: > src/configs/thunderx2/$(am__dirstamp)
+src/configs/thunderx2/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) src/configs/thunderx2/$(DEPDIR)
+	@: > src/configs/thunderx2/$(DEPDIR)/$(am__dirstamp)
+src/configs/thunderx2/config.lo:  \
+	src/configs/thunderx2/$(am__dirstamp) \
+	src/configs/thunderx2/$(DEPDIR)/$(am__dirstamp)
 
 lib/libtblis.la: $(lib_libtblis_la_OBJECTS) $(lib_libtblis_la_DEPENDENCIES) $(EXTRA_lib_libtblis_la_DEPENDENCIES) lib/$(am__dirstamp)
 	$(AM_V_CXXLD)$(CXXLINK) -rpath $(libdir) $(lib_libtblis_la_OBJECTS) $(lib_libtblis_la_LIBADD) $(LIBS)
+src/configs/thunderx2/config_ker.lo:  \
+	src/configs/thunderx2/$(am__dirstamp) \
+	src/configs/thunderx2/$(DEPDIR)/$(am__dirstamp)
+src/configs/armv8a/lib_libthunderx2_la-bli_gemm_asm_d6x8.lo:  \
+	src/configs/armv8a/$(am__dirstamp) \
+	src/configs/armv8a/$(DEPDIR)/$(am__dirstamp)
+
+lib/libthunderx2.la: $(lib_libthunderx2_la_OBJECTS) $(lib_libthunderx2_la_DEPENDENCIES) $(EXTRA_lib_libthunderx2_la_DEPENDENCIES) lib/$(am__dirstamp)
+	$(AM_V_CXXLD)$(CXXLINK) $(am_lib_libthunderx2_la_rpath) $(lib_libthunderx2_la_OBJECTS) $(lib_libthunderx2_la_LIBADD) $(LIBS)
 src/configs/zen/lib_libzen_la-config_ker.lo:  \
 	src/configs/zen/$(am__dirstamp) \
 	src/configs/zen/$(DEPDIR)/$(am__dirstamp)
@@ -1705,6 +1853,10 @@ mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
 	-rm -f src/configs/*.$(OBJEXT)
 	-rm -f src/configs/*.lo
+	-rm -f src/configs/armv7a/*.$(OBJEXT)
+	-rm -f src/configs/armv7a/*.lo
+	-rm -f src/configs/armv8a/*.$(OBJEXT)
+	-rm -f src/configs/armv8a/*.lo
 	-rm -f src/configs/bulldozer/*.$(OBJEXT)
 	-rm -f src/configs/bulldozer/*.lo
 	-rm -f src/configs/core2/*.$(OBJEXT)
@@ -1725,6 +1877,8 @@ mostlyclean-compile:
 	-rm -f src/configs/skx1/*.lo
 	-rm -f src/configs/skx2/*.$(OBJEXT)
 	-rm -f src/configs/skx2/*.lo
+	-rm -f src/configs/thunderx2/*.$(OBJEXT)
+	-rm -f src/configs/thunderx2/*.lo
 	-rm -f src/configs/zen/*.$(OBJEXT)
 	-rm -f src/configs/zen/*.lo
 	-rm -f src/iface/1t/*.$(OBJEXT)
@@ -1760,6 +1914,13 @@ distclean-compile:
 	-rm -f *.tab.c
 
 @AMDEP_TRUE@@am__include@ @am__quote@src/configs/$(DEPDIR)/configs.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/configs/armv7a/$(DEPDIR)/config.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/configs/armv7a/$(DEPDIR)/config_ker.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/configs/armv7a/$(DEPDIR)/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/configs/armv8a/$(DEPDIR)/config.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/configs/armv8a/$(DEPDIR)/config_ker.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/configs/armv8a/$(DEPDIR)/lib_libarmv8a_la-bli_gemm_asm_d6x8.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/configs/armv8a/$(DEPDIR)/lib_libthunderx2_la-bli_gemm_asm_d6x8.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/configs/bulldozer/$(DEPDIR)/config.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/configs/bulldozer/$(DEPDIR)/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/configs/bulldozer/$(DEPDIR)/lib_libbulldozer_la-config_ker.Plo@am__quote@ # am--include-marker
@@ -1795,6 +1956,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/configs/skx2/$(DEPDIR)/lib_libskx2_la-bli_sgemm_opt_12x32_l2.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/configs/skx2/$(DEPDIR)/lib_libskx2_la-config_ker.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/configs/skx2/$(DEPDIR)/vpu_count.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/configs/thunderx2/$(DEPDIR)/config.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/configs/thunderx2/$(DEPDIR)/config_ker.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/configs/zen/$(DEPDIR)/config.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/configs/zen/$(DEPDIR)/lib_libzen_la-config_ker.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/iface/1t/$(DEPDIR)/add.Plo@am__quote@ # am--include-marker
@@ -1890,6 +2053,20 @@ am--depfiles: $(am__depfiles_remade)
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='$<' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LTCOMPILE) -c -o $@ $<
+
+src/configs/armv7a/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.lo: src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_libarmv7a_la_CFLAGS) $(CFLAGS) -MT src/configs/armv7a/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.lo -MD -MP -MF src/configs/armv7a/$(DEPDIR)/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.Tpo -c -o src/configs/armv7a/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.lo `test -f 'src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c' || echo '$(srcdir)/'`src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/configs/armv7a/$(DEPDIR)/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.Tpo src/configs/armv7a/$(DEPDIR)/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c' object='src/configs/armv7a/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_libarmv7a_la_CFLAGS) $(CFLAGS) -c -o src/configs/armv7a/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.lo `test -f 'src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c' || echo '$(srcdir)/'`src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c
+
+src/configs/armv8a/lib_libarmv8a_la-bli_gemm_asm_d6x8.lo: src/configs/armv8a/bli_gemm_asm_d6x8.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_libarmv8a_la_CFLAGS) $(CFLAGS) -MT src/configs/armv8a/lib_libarmv8a_la-bli_gemm_asm_d6x8.lo -MD -MP -MF src/configs/armv8a/$(DEPDIR)/lib_libarmv8a_la-bli_gemm_asm_d6x8.Tpo -c -o src/configs/armv8a/lib_libarmv8a_la-bli_gemm_asm_d6x8.lo `test -f 'src/configs/armv8a/bli_gemm_asm_d6x8.c' || echo '$(srcdir)/'`src/configs/armv8a/bli_gemm_asm_d6x8.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/configs/armv8a/$(DEPDIR)/lib_libarmv8a_la-bli_gemm_asm_d6x8.Tpo src/configs/armv8a/$(DEPDIR)/lib_libarmv8a_la-bli_gemm_asm_d6x8.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/configs/armv8a/bli_gemm_asm_d6x8.c' object='src/configs/armv8a/lib_libarmv8a_la-bli_gemm_asm_d6x8.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_libarmv8a_la_CFLAGS) $(CFLAGS) -c -o src/configs/armv8a/lib_libarmv8a_la-bli_gemm_asm_d6x8.lo `test -f 'src/configs/armv8a/bli_gemm_asm_d6x8.c' || echo '$(srcdir)/'`src/configs/armv8a/bli_gemm_asm_d6x8.c
 
 src/configs/bulldozer/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.lo: src/configs/bulldozer/bli_gemm_asm_d4x6_fma4.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_libbulldozer_la_CFLAGS) $(CFLAGS) -MT src/configs/bulldozer/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.lo -MD -MP -MF src/configs/bulldozer/$(DEPDIR)/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.Tpo -c -o src/configs/bulldozer/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.lo `test -f 'src/configs/bulldozer/bli_gemm_asm_d4x6_fma4.c' || echo '$(srcdir)/'`src/configs/bulldozer/bli_gemm_asm_d4x6_fma4.c
@@ -1988,6 +2165,13 @@ src/configs/skx2/lib_libskx2_la-bli_dgemm_opt_12x16_l2.lo: src/configs/skx2/bli_
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/configs/skx2/bli_dgemm_opt_12x16_l2.c' object='src/configs/skx2/lib_libskx2_la-bli_dgemm_opt_12x16_l2.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_libskx2_la_CFLAGS) $(CFLAGS) -c -o src/configs/skx2/lib_libskx2_la-bli_dgemm_opt_12x16_l2.lo `test -f 'src/configs/skx2/bli_dgemm_opt_12x16_l2.c' || echo '$(srcdir)/'`src/configs/skx2/bli_dgemm_opt_12x16_l2.c
+
+src/configs/armv8a/lib_libthunderx2_la-bli_gemm_asm_d6x8.lo: src/configs/armv8a/bli_gemm_asm_d6x8.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_libthunderx2_la_CFLAGS) $(CFLAGS) -MT src/configs/armv8a/lib_libthunderx2_la-bli_gemm_asm_d6x8.lo -MD -MP -MF src/configs/armv8a/$(DEPDIR)/lib_libthunderx2_la-bli_gemm_asm_d6x8.Tpo -c -o src/configs/armv8a/lib_libthunderx2_la-bli_gemm_asm_d6x8.lo `test -f 'src/configs/armv8a/bli_gemm_asm_d6x8.c' || echo '$(srcdir)/'`src/configs/armv8a/bli_gemm_asm_d6x8.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/configs/armv8a/$(DEPDIR)/lib_libthunderx2_la-bli_gemm_asm_d6x8.Tpo src/configs/armv8a/$(DEPDIR)/lib_libthunderx2_la-bli_gemm_asm_d6x8.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/configs/armv8a/bli_gemm_asm_d6x8.c' object='src/configs/armv8a/lib_libthunderx2_la-bli_gemm_asm_d6x8.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_libthunderx2_la_CFLAGS) $(CFLAGS) -c -o src/configs/armv8a/lib_libthunderx2_la-bli_gemm_asm_d6x8.lo `test -f 'src/configs/armv8a/bli_gemm_asm_d6x8.c' || echo '$(srcdir)/'`src/configs/armv8a/bli_gemm_asm_d6x8.c
 
 src/configs/haswell/lib_libzen_la-bli_gemm_asm_d6x8.lo: src/configs/haswell/bli_gemm_asm_d6x8.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_libzen_la_CFLAGS) $(CFLAGS) -MT src/configs/haswell/lib_libzen_la-bli_gemm_asm_d6x8.lo -MD -MP -MF src/configs/haswell/$(DEPDIR)/lib_libzen_la-bli_gemm_asm_d6x8.Tpo -c -o src/configs/haswell/lib_libzen_la-bli_gemm_asm_d6x8.lo `test -f 'src/configs/haswell/bli_gemm_asm_d6x8.c' || echo '$(srcdir)/'`src/configs/haswell/bli_gemm_asm_d6x8.c
@@ -2105,6 +2289,8 @@ clean-libtool:
 	-rm -rf bin/.libs bin/_libs
 	-rm -rf lib/.libs lib/_libs
 	-rm -rf src/configs/.libs src/configs/_libs
+	-rm -rf src/configs/armv7a/.libs src/configs/armv7a/_libs
+	-rm -rf src/configs/armv8a/.libs src/configs/armv8a/_libs
 	-rm -rf src/configs/bulldozer/.libs src/configs/bulldozer/_libs
 	-rm -rf src/configs/core2/.libs src/configs/core2/_libs
 	-rm -rf src/configs/excavator/.libs src/configs/excavator/_libs
@@ -2115,6 +2301,7 @@ clean-libtool:
 	-rm -rf src/configs/sandybridge/.libs src/configs/sandybridge/_libs
 	-rm -rf src/configs/skx1/.libs src/configs/skx1/_libs
 	-rm -rf src/configs/skx2/.libs src/configs/skx2/_libs
+	-rm -rf src/configs/thunderx2/.libs src/configs/thunderx2/_libs
 	-rm -rf src/configs/zen/.libs src/configs/zen/_libs
 	-rm -rf src/iface/1t/.libs src/iface/1t/_libs
 	-rm -rf src/iface/3t/.libs src/iface/3t/_libs
@@ -2620,6 +2807,10 @@ distclean-generic:
 	-rm -f lib/$(am__dirstamp)
 	-rm -f src/configs/$(DEPDIR)/$(am__dirstamp)
 	-rm -f src/configs/$(am__dirstamp)
+	-rm -f src/configs/armv7a/$(DEPDIR)/$(am__dirstamp)
+	-rm -f src/configs/armv7a/$(am__dirstamp)
+	-rm -f src/configs/armv8a/$(DEPDIR)/$(am__dirstamp)
+	-rm -f src/configs/armv8a/$(am__dirstamp)
 	-rm -f src/configs/bulldozer/$(DEPDIR)/$(am__dirstamp)
 	-rm -f src/configs/bulldozer/$(am__dirstamp)
 	-rm -f src/configs/core2/$(DEPDIR)/$(am__dirstamp)
@@ -2640,6 +2831,8 @@ distclean-generic:
 	-rm -f src/configs/skx1/$(am__dirstamp)
 	-rm -f src/configs/skx2/$(DEPDIR)/$(am__dirstamp)
 	-rm -f src/configs/skx2/$(am__dirstamp)
+	-rm -f src/configs/thunderx2/$(DEPDIR)/$(am__dirstamp)
+	-rm -f src/configs/thunderx2/$(am__dirstamp)
 	-rm -f src/configs/zen/$(DEPDIR)/$(am__dirstamp)
 	-rm -f src/configs/zen/$(am__dirstamp)
 	-rm -f src/iface/1t/$(DEPDIR)/$(am__dirstamp)
@@ -2687,6 +2880,13 @@ clean-am: clean-generic clean-libLTLIBRARIES clean-libtool \
 distclean: distclean-recursive
 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
 		-rm -f src/configs/$(DEPDIR)/configs.Plo
+	-rm -f src/configs/armv7a/$(DEPDIR)/config.Plo
+	-rm -f src/configs/armv7a/$(DEPDIR)/config_ker.Plo
+	-rm -f src/configs/armv7a/$(DEPDIR)/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.Plo
+	-rm -f src/configs/armv8a/$(DEPDIR)/config.Plo
+	-rm -f src/configs/armv8a/$(DEPDIR)/config_ker.Plo
+	-rm -f src/configs/armv8a/$(DEPDIR)/lib_libarmv8a_la-bli_gemm_asm_d6x8.Plo
+	-rm -f src/configs/armv8a/$(DEPDIR)/lib_libthunderx2_la-bli_gemm_asm_d6x8.Plo
 	-rm -f src/configs/bulldozer/$(DEPDIR)/config.Plo
 	-rm -f src/configs/bulldozer/$(DEPDIR)/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.Plo
 	-rm -f src/configs/bulldozer/$(DEPDIR)/lib_libbulldozer_la-config_ker.Plo
@@ -2722,6 +2922,8 @@ distclean: distclean-recursive
 	-rm -f src/configs/skx2/$(DEPDIR)/lib_libskx2_la-bli_sgemm_opt_12x32_l2.Plo
 	-rm -f src/configs/skx2/$(DEPDIR)/lib_libskx2_la-config_ker.Plo
 	-rm -f src/configs/skx2/$(DEPDIR)/vpu_count.Plo
+	-rm -f src/configs/thunderx2/$(DEPDIR)/config.Plo
+	-rm -f src/configs/thunderx2/$(DEPDIR)/config_ker.Plo
 	-rm -f src/configs/zen/$(DEPDIR)/config.Plo
 	-rm -f src/configs/zen/$(DEPDIR)/lib_libzen_la-config_ker.Plo
 	-rm -f src/iface/1t/$(DEPDIR)/add.Plo
@@ -2838,6 +3040,13 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
 	-rm -rf $(top_srcdir)/autom4te.cache
 		-rm -f src/configs/$(DEPDIR)/configs.Plo
+	-rm -f src/configs/armv7a/$(DEPDIR)/config.Plo
+	-rm -f src/configs/armv7a/$(DEPDIR)/config_ker.Plo
+	-rm -f src/configs/armv7a/$(DEPDIR)/lib_libarmv7a_la-bli_gemm_armv7a_int_d4x4.Plo
+	-rm -f src/configs/armv8a/$(DEPDIR)/config.Plo
+	-rm -f src/configs/armv8a/$(DEPDIR)/config_ker.Plo
+	-rm -f src/configs/armv8a/$(DEPDIR)/lib_libarmv8a_la-bli_gemm_asm_d6x8.Plo
+	-rm -f src/configs/armv8a/$(DEPDIR)/lib_libthunderx2_la-bli_gemm_asm_d6x8.Plo
 	-rm -f src/configs/bulldozer/$(DEPDIR)/config.Plo
 	-rm -f src/configs/bulldozer/$(DEPDIR)/lib_libbulldozer_la-bli_gemm_asm_d4x6_fma4.Plo
 	-rm -f src/configs/bulldozer/$(DEPDIR)/lib_libbulldozer_la-config_ker.Plo
@@ -2873,6 +3082,8 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f src/configs/skx2/$(DEPDIR)/lib_libskx2_la-bli_sgemm_opt_12x32_l2.Plo
 	-rm -f src/configs/skx2/$(DEPDIR)/lib_libskx2_la-config_ker.Plo
 	-rm -f src/configs/skx2/$(DEPDIR)/vpu_count.Plo
+	-rm -f src/configs/thunderx2/$(DEPDIR)/config.Plo
+	-rm -f src/configs/thunderx2/$(DEPDIR)/config_ker.Plo
 	-rm -f src/configs/zen/$(DEPDIR)/config.Plo
 	-rm -f src/configs/zen/$(DEPDIR)/lib_libzen_la-config_ker.Plo
 	-rm -f src/iface/1t/$(DEPDIR)/add.Plo

--- a/configure
+++ b/configure
@@ -694,6 +694,12 @@ ENABLE_BULLDOZER_FALSE
 ENABLE_BULLDOZER_TRUE
 ENABLE_BGQ_FALSE
 ENABLE_BGQ_TRUE
+ENABLE_A64FX_FALSE
+ENABLE_A64FX_TRUE
+ENABLE_ARMV8A_SVE_FALSE
+ENABLE_ARMV8A_SVE_TRUE
+ENABLE_THUNDERX2_FALSE
+ENABLE_THUNDERX2_TRUE
 ENABLE_ARMV8A_FALSE
 ENABLE_ARMV8A_TRUE
 ENABLE_ARMV7A_FALSE
@@ -1486,11 +1492,15 @@ Optional Features:
 
                           possible values are:
 
-                          reference, bulldozer, piledriver, excavator, zen,
-                          core2, sandybridge, haswell, skx1, skx2, knl, auto
+                          reference, auto,
+                          core2, sandybridge, haswell, skx1, skx2, knl,
+                          bulldozer, piledriver, excavator, zen,
+                          armv7a, armv8a, thunderx2, armv8a_sve, a64fx
 
                           the following meta-configurations are also available:
 
+                          arm32 = armv7a,
+                          arm64 = armv8a,thunderx2,armv8a_sve,a64fx
                           skx = skx1,skx2
                           intel = core2,sandybridge,haswell,skx,knl
                           amd = bulldozer,piledriver,excavator,zen
@@ -6032,12 +6042,14 @@ _ACEOF
 #
 # Supported:
 #
-# reference, bulldozer, piledriver, excavator, zen, core2, sandybridge,
-# haswell, skx1, skx2, knl, auto
+# reference, auto,
+# core2, sandybridge, haswell, skx1, skx2, knl,
+# bulldozer, piledriver, excavator, zen,
+# armv7a, armv8a, thunderx2, armv8a_sve, a64fx
 #
 # Possible with porting from BLIS:
 #
-# armv7a, armv8a, bgq, cortex-a15, cortex-a9, power7, loongson3a, mic
+# loongson3a, power7, bgq, mic
 #
 
 # Check whether --enable-config was given.
@@ -6192,9 +6204,111 @@ $as_echo "$ac_cv_defined__M_IX86" >&6; }
 if test $ac_cv_defined__M_IX86 != "no"; then :
   enable_config=x86
 fi
-#    AC_CHECK_DEFINE([__aarch64__], [enable_config=arm])
-#    AC_CHECK_DEFINE([__arm__], [enable_config=arm])
-#    AC_CHECK_DEFINE([_M_ARM], [enable_config=arm])
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __aarch64__ defined" >&5
+$as_echo_n "checking for __aarch64__ defined... " >&6; }
+if ${ac_cv_defined___aarch64__+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  #ifdef __aarch64__
+  int ok;
+  #else
+  choke me
+  #endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_defined___aarch64__=yes
+else
+  ac_cv_defined___aarch64__=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_defined___aarch64__" >&5
+$as_echo "$ac_cv_defined___aarch64__" >&6; }
+if test $ac_cv_defined___aarch64__ != "no"; then :
+  enable_config=arm64
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __arm__ defined" >&5
+$as_echo_n "checking for __arm__ defined... " >&6; }
+if ${ac_cv_defined___arm__+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  #ifdef __arm__
+  int ok;
+  #else
+  choke me
+  #endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_defined___arm__=yes
+else
+  ac_cv_defined___arm__=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_defined___arm__" >&5
+$as_echo "$ac_cv_defined___arm__" >&6; }
+if test $ac_cv_defined___arm__ != "no"; then :
+  enable_config=arm32
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for _M_ARM defined" >&5
+$as_echo_n "checking for _M_ARM defined... " >&6; }
+if ${ac_cv_defined__M_ARM+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  #ifdef _M_ARM
+  int ok;
+  #else
+  choke me
+  #endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_defined__M_ARM=yes
+else
+  ac_cv_defined__M_ARM=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_defined__M_ARM" >&5
+$as_echo "$ac_cv_defined__M_ARM" >&6; }
+if test $ac_cv_defined__M_ARM != "no"; then :
+  enable_config=arm32
+fi
 #    AC_CHECK_DEFINE([__powerpc64__], [enable_config=power7])
 #    AC_CHECK_DEFINE([__ppc64__], [enable_config=power7])
 #    AC_CHECK_DEFINE([__PPC64__], [enable_config=power7])
@@ -6249,10 +6363,12 @@ configs=`echo $enable_config | sed 's/x86/intel,amd/' \
                              | sed 's/amd/bulldozer,piledriver,excavator,zen/' \
                              | sed 's/skx,/skx1,skx2,/' \
                              | sed 's/skx$/skx1,skx2/' \
+                             | sed 's/arm64/armv8a,thunderx2,armv8a_sve,a64fx/' \
+                             | sed 's/arm32/armv7a/' \
                              | sed 's/,/ /g'`
 
 for config in $configs; do
-    if ( echo $config | $EGREP -qv '^(reference|core2|sandybridge|haswell|skx1|skx2|knl|bulldozer|piledriver|excavator|zen)$' ); then
+    if ( echo $config | $EGREP -qv '^(reference|core2|sandybridge|haswell|skx1|skx2|knl|bulldozer|piledriver|excavator|zen|armv7a|armv8a|thunderx2|armv8a_sve|a64fx)$' ); then
         as_fn_error $? "Unknown configuration $config" "$LINENO" 5
     fi
 done
@@ -6609,6 +6725,30 @@ fi
 else
   ENABLE_ARMV8A_TRUE='#'
   ENABLE_ARMV8A_FALSE=
+fi
+
+ if echo $configs | grep -q thunderx2; then
+  ENABLE_THUNDERX2_TRUE=
+  ENABLE_THUNDERX2_FALSE='#'
+else
+  ENABLE_THUNDERX2_TRUE='#'
+  ENABLE_THUNDERX2_FALSE=
+fi
+
+ if echo $configs | grep -q armv8a_sve; then
+  ENABLE_ARMV8A_SVE_TRUE=
+  ENABLE_ARMV8A_SVE_FALSE='#'
+else
+  ENABLE_ARMV8A_SVE_TRUE='#'
+  ENABLE_ARMV8A_SVE_FALSE=
+fi
+
+ if echo $configs | grep -q a64fx; then
+  ENABLE_A64FX_TRUE=
+  ENABLE_A64FX_FALSE='#'
+else
+  ENABLE_A64FX_TRUE='#'
+  ENABLE_A64FX_FALSE=
 fi
 
  if echo $configs | grep -q bgq; then
@@ -17880,6 +18020,18 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${ENABLE_ARMV8A_TRUE}" && test -z "${ENABLE_ARMV8A_FALSE}"; then
   as_fn_error $? "conditional \"ENABLE_ARMV8A\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${ENABLE_THUNDERX2_TRUE}" && test -z "${ENABLE_THUNDERX2_FALSE}"; then
+  as_fn_error $? "conditional \"ENABLE_THUNDERX2\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${ENABLE_ARMV8A_SVE_TRUE}" && test -z "${ENABLE_ARMV8A_SVE_FALSE}"; then
+  as_fn_error $? "conditional \"ENABLE_ARMV8A_SVE\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${ENABLE_A64FX_TRUE}" && test -z "${ENABLE_A64FX_FALSE}"; then
+  as_fn_error $? "conditional \"ENABLE_A64FX\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${ENABLE_BGQ_TRUE}" && test -z "${ENABLE_BGQ_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -152,12 +152,14 @@ AC_DEFINE_UNQUOTED([LABEL_TYPE], [$label_type], [label_type])
 #
 # Supported:
 #
-# reference, bulldozer, piledriver, excavator, zen, core2, sandybridge,
-# haswell, skx1, skx2, knl, auto
+# reference, auto,
+# core2, sandybridge, haswell, skx1, skx2, knl,
+# bulldozer, piledriver, excavator, zen,
+# armv7a, armv8a, thunderx2, armv8a_sve, a64fx
 #
 # Possible with porting from BLIS:
 #
-# armv7a, armv8a, bgq, cortex-a15, cortex-a9, power7, loongson3a, mic
+# loongson3a, power7, bgq, mic
 #
 
 AC_ARG_ENABLE([config],
@@ -166,11 +168,15 @@ AC_ARG_ENABLE([config],
   
                           possible values are:
                           
-                          reference, bulldozer, piledriver, excavator, zen,
-                          core2, sandybridge, haswell, skx1, skx2, knl, auto
+                          reference, auto,
+                          core2, sandybridge, haswell, skx1, skx2, knl,
+                          bulldozer, piledriver, excavator, zen,
+                          armv7a, armv8a, thunderx2, armv8a_sve, a64fx
 
                           the following meta-configurations are also available:
  
+                          arm32 = armv7a,
+                          arm64 = armv8a,thunderx2,armv8a_sve,a64fx
                           skx = skx1,skx2
                           intel = core2,sandybridge,haswell,skx,knl
                           amd = bulldozer,piledriver,excavator,zen
@@ -185,9 +191,9 @@ if echo $enable_config | grep -q auto; then
     AC_CHECK_DEFINE([_M_X64], [enable_config=x86])
     AC_CHECK_DEFINE([__i386], [enable_config=x86])
     AC_CHECK_DEFINE([_M_IX86], [enable_config=x86])
-#    AC_CHECK_DEFINE([__aarch64__], [enable_config=arm])
-#    AC_CHECK_DEFINE([__arm__], [enable_config=arm])
-#    AC_CHECK_DEFINE([_M_ARM], [enable_config=arm])
+    AC_CHECK_DEFINE([__aarch64__], [enable_config=arm64])
+    AC_CHECK_DEFINE([__arm__], [enable_config=arm32])
+    AC_CHECK_DEFINE([_M_ARM], [enable_config=arm32])
 #    AC_CHECK_DEFINE([__powerpc64__], [enable_config=power7])
 #    AC_CHECK_DEFINE([__ppc64__], [enable_config=power7])
 #    AC_CHECK_DEFINE([__PPC64__], [enable_config=power7])
@@ -208,10 +214,12 @@ configs=`echo $enable_config | sed 's/x86/intel,amd/' \
                              | sed 's/amd/bulldozer,piledriver,excavator,zen/' \
                              | sed 's/skx,/skx1,skx2,/' \
                              | sed 's/skx$/skx1,skx2/' \
+                             | sed 's/arm64/armv8a,thunderx2,armv8a_sve,a64fx/' \
+                             | sed 's/arm32/armv7a/' \
                              | sed 's/,/ /g'`
 
 for config in $configs; do
-    if ( echo $config | $EGREP -qv '^(reference|core2|sandybridge|haswell|skx1|skx2|knl|bulldozer|piledriver|excavator|zen)$' ); then
+    if ( echo $config | $EGREP -qv '^(reference|core2|sandybridge|haswell|skx1|skx2|knl|bulldozer|piledriver|excavator|zen|armv7a|armv8a|thunderx2|armv8a_sve|a64fx)$' ); then
         AC_MSG_ERROR([Unknown configuration $config])
     fi
 done
@@ -415,6 +423,9 @@ AC_MSG_RESULT([$configs])
 
 AM_CONDITIONAL(ENABLE_ARMV7A, [echo $configs | grep -q armv7a])
 AM_CONDITIONAL(ENABLE_ARMV8A, [echo $configs | grep -q armv8a])
+AM_CONDITIONAL(ENABLE_THUNDERX2, [echo $configs | grep -q thunderx2])
+AM_CONDITIONAL(ENABLE_ARMV8A_SVE, [echo $configs | grep -q armv8a_sve])
+AM_CONDITIONAL(ENABLE_A64FX, [echo $configs | grep -q a64fx])
 AM_CONDITIONAL(ENABLE_BGQ, [echo $configs | grep -q bgq])
 AM_CONDITIONAL(ENABLE_BULLDOZER, [echo $configs | grep -q bulldozer])
 AM_CONDITIONAL(ENABLE_EXCAVATOR, [echo $configs | grep -q excavator])

--- a/src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c
+++ b/src/configs/armv7a/bli_gemm_armv7a_int_d4x4.c
@@ -1,0 +1,547 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "blis.h"
+#include "arm_neon.h"
+
+void bli_sgemm_armv7a_int_4x4
+     (
+       dim_t               k0,
+       float*     restrict alpha,
+       float*     restrict a,
+       float*     restrict b,
+       float*     restrict beta,
+       float*     restrict c, inc_t rs_c0, inc_t cs_c0,
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
+     )
+{
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	uint32_t k_iter = k0 / 4;
+	uint32_t k_left = k0 % 4;
+	uint32_t rs_c   = rs_c0;
+	uint32_t cs_c   = cs_c0;
+	uint32_t i;
+
+	void* a_next = bli_auxinfo_next_a( data );
+	void* b_next = bli_auxinfo_next_b( data );
+
+	float32x4_t alphav;
+	alphav = vmovq_n_f32( *alpha );
+
+	float32x4_t av1;
+	float32x4_t av2;
+	float32x4_t av3;
+	float32x4_t av4;
+
+	float32x4_t bv1;
+	float32x4_t bv2;
+	float32x4_t bv3;
+	float32x4_t bv4;
+
+	// Vector for column 0
+	float32x4_t cv0;
+	// Vector for column 1
+	float32x4_t cv1;
+	// Vector for column 2
+	float32x4_t cv2;
+	// Vector for column 3
+	float32x4_t cv3;
+
+	if ( *beta != 0.0F )
+	{
+		if ( rs_c == 1 )
+		{
+			// Load column 0
+			cv0 = vld1q_f32( c + 0*rs_c + 0*cs_c );
+
+			// Load column 1
+			cv1 = vld1q_f32( c + 0*rs_c + 1*cs_c );
+
+			// Load column 2
+			cv2 = vld1q_f32( c + 0*rs_c + 2*cs_c );
+
+			// Load column 3
+			cv3 = vld1q_f32( c + 0*rs_c + 3*cs_c );
+		}
+		else
+		{
+			// Load column 0
+			cv0 = vld1q_lane_f32( c + 0*rs_c + 0*cs_c, cv0, 0);
+			cv0 = vld1q_lane_f32( c + 1*rs_c + 0*cs_c, cv0, 1);
+			cv0 = vld1q_lane_f32( c + 2*rs_c + 0*cs_c, cv0, 2);
+			cv0 = vld1q_lane_f32( c + 3*rs_c + 0*cs_c, cv0, 3);
+
+			// Load column 1
+			cv1 = vld1q_lane_f32( c + 0*rs_c + 1*cs_c, cv1, 0);
+			cv1 = vld1q_lane_f32( c + 1*rs_c + 1*cs_c, cv1, 1);
+			cv1 = vld1q_lane_f32( c + 2*rs_c + 1*cs_c, cv1, 2);
+			cv1 = vld1q_lane_f32( c + 3*rs_c + 1*cs_c, cv1, 3);
+
+			// Load column 2
+			cv2 = vld1q_lane_f32( c + 0*rs_c + 2*cs_c, cv2, 0);
+			cv2 = vld1q_lane_f32( c + 1*rs_c + 2*cs_c, cv2, 1);
+			cv2 = vld1q_lane_f32( c + 2*rs_c + 2*cs_c, cv2, 2);
+			cv2 = vld1q_lane_f32( c + 3*rs_c + 2*cs_c, cv2, 3);
+
+			// Load column 3
+			cv3 = vld1q_lane_f32( c + 0*rs_c + 3*cs_c, cv3, 0);
+			cv3 = vld1q_lane_f32( c + 1*rs_c + 3*cs_c, cv3, 1);
+			cv3 = vld1q_lane_f32( c + 2*rs_c + 3*cs_c, cv3, 2);
+			cv3 = vld1q_lane_f32( c + 3*rs_c + 3*cs_c, cv3, 3);
+
+		}
+	}
+	else
+	{
+		cv0 = vmovq_n_f32( 0.0 );
+		cv1 = vmovq_n_f32( 0.0 );
+		cv2 = vmovq_n_f32( 0.0 );
+		cv3 = vmovq_n_f32( 0.0 );
+	}
+
+	// Vector for accummulating column 0
+	float32x4_t abv0;
+	// Initialize vector to 0.0
+	abv0 = vmovq_n_f32( 0.0 );
+
+	// Vector for accummulating column 1
+	float32x4_t abv1;
+	// Initialize vector to 0.0
+	abv1 = vmovq_n_f32( 0.0 );
+
+	// Vector for accummulating column 2
+	float32x4_t abv2;
+	// Initialize vector to 0.0
+	abv2 = vmovq_n_f32( 0.0 );
+
+	// Vector for accummulating column 3
+	float32x4_t abv3;
+	// Initialize vector to 0.0
+	abv3 = vmovq_n_f32( 0.0 );
+
+	for ( i = 0; i < k_iter; ++i )
+	{
+		// Begin iter 0
+			av1 = vld1q_f32( a );
+
+		__builtin_prefetch( a + 224 );
+		__builtin_prefetch( b + 224 );
+
+		bv1 = vld1q_f32( b );
+
+		abv0 = vmlaq_lane_f32( abv0, av1, vget_low_f32(bv1), 0 );
+		abv1 = vmlaq_lane_f32( abv1, av1, vget_low_f32(bv1), 1 );
+		abv2 = vmlaq_lane_f32( abv2, av1, vget_high_f32(bv1), 0 );
+		abv3 = vmlaq_lane_f32( abv3, av1, vget_high_f32(bv1), 1 );
+
+
+		av2 = vld1q_f32( a+4 );
+
+		//__builtin_prefetch( a + 116 );
+		//__builtin_prefetch( b + 116 );
+
+		bv2 = vld1q_f32( b+4 );
+
+		abv0 = vmlaq_lane_f32( abv0, av2, vget_low_f32(bv2), 0 );
+		abv1 = vmlaq_lane_f32( abv1, av2, vget_low_f32(bv2), 1 );
+		abv2 = vmlaq_lane_f32( abv2, av2, vget_high_f32(bv2), 0 );
+		abv3 = vmlaq_lane_f32( abv3, av2, vget_high_f32(bv2), 1 );
+
+		av3 = vld1q_f32( a+8 );
+
+		//__builtin_prefetch( a + 120 );
+		//__builtin_prefetch( b + 120 );
+
+		bv3 = vld1q_f32( b+8 );
+
+		abv0 = vmlaq_lane_f32( abv0, av3, vget_low_f32(bv3), 0 );
+		abv1 = vmlaq_lane_f32( abv1, av3, vget_low_f32(bv3), 1 );
+		abv2 = vmlaq_lane_f32( abv2, av3, vget_high_f32(bv3), 0 );
+		abv3 = vmlaq_lane_f32( abv3, av3, vget_high_f32(bv3), 1 );
+
+
+		av4 = vld1q_f32( a+12);
+
+		//__builtin_prefetch( a + 124 );
+		//__builtin_prefetch( b + 124 );
+
+		bv4 = vld1q_f32( b+12);
+
+		abv0 = vmlaq_lane_f32( abv0, av4, vget_low_f32(bv4), 0 );
+		abv1 = vmlaq_lane_f32( abv1, av4, vget_low_f32(bv4), 1 );
+		abv2 = vmlaq_lane_f32( abv2, av4, vget_high_f32(bv4), 0 );
+		abv3 = vmlaq_lane_f32( abv3, av4, vget_high_f32(bv4), 1 );
+
+
+
+		a += 16;
+		b += 16;
+	}
+
+	for ( i = 0; i < k_left; ++i )
+	{
+		av1 = vld1q_f32( a );
+
+		__builtin_prefetch( a + 112 );
+		__builtin_prefetch( b + 112 );
+
+		bv1 = vld1q_f32( b );
+
+		abv0 = vmlaq_lane_f32( abv0, av1, vget_low_f32(bv1), 0 );
+		abv1 = vmlaq_lane_f32( abv1, av1, vget_low_f32(bv1), 1 );
+		abv2 = vmlaq_lane_f32( abv2, av1, vget_high_f32(bv1), 0 );
+		abv3 = vmlaq_lane_f32( abv3, av1, vget_high_f32(bv1), 1 );
+
+		a += 4;
+		b += 4;
+	}
+
+	__builtin_prefetch( a_next );
+	__builtin_prefetch( b_next );
+
+	if ( *beta != 0.0F )
+	{
+		// Multiply C by beta and then accumulate alpha * A * B.
+		cv0 = vmulq_n_f32( cv0, *beta );
+		cv1 = vmulq_n_f32( cv1, *beta );
+		cv2 = vmulq_n_f32( cv2, *beta );
+		cv3 = vmulq_n_f32( cv3, *beta );
+
+		cv0 = vmlaq_f32( cv0, abv0, alphav );
+		cv1 = vmlaq_f32( cv1, abv1, alphav );
+		cv2 = vmlaq_f32( cv2, abv2, alphav );
+		cv3 = vmlaq_f32( cv3, abv3, alphav );
+	}
+	else
+	{
+		// Since beta = 0, skip straight to accumulating alpha * A * B.
+		// Note: C (cv?) was initialized to zero above.
+		cv0 = vmlaq_f32( cv0, abv0, alphav );
+		cv1 = vmlaq_f32( cv1, abv1, alphav );
+		cv2 = vmlaq_f32( cv2, abv2, alphav );
+		cv3 = vmlaq_f32( cv3, abv3, alphav );
+	}
+
+	if ( rs_c == 1 )
+	{
+		// Store column 0
+		vst1q_f32( c + 0*rs_c + 0*cs_c, cv0 );
+		// Store column 1
+		vst1q_f32( c + 0*rs_c + 1*cs_c, cv1 );
+		// Store column 2
+		vst1q_f32( c + 0*rs_c + 2*cs_c, cv2 );
+		// Store column 3
+		vst1q_f32( c + 0*rs_c + 3*cs_c, cv3 );
+	}
+	else
+	{
+		// Store column 0
+		vst1q_lane_f32( c + 0*rs_c + 0*cs_c, cv0, 0);
+		vst1q_lane_f32( c + 1*rs_c + 0*cs_c, cv0, 1);
+		vst1q_lane_f32( c + 2*rs_c + 0*cs_c, cv0, 2);
+		vst1q_lane_f32( c + 3*rs_c + 0*cs_c, cv0, 3);
+
+		// Store column 1
+		vst1q_lane_f32( c + 0*rs_c + 1*cs_c, cv1, 0);
+		vst1q_lane_f32( c + 1*rs_c + 1*cs_c, cv1, 1);
+		vst1q_lane_f32( c + 2*rs_c + 1*cs_c, cv1, 2);
+		vst1q_lane_f32( c + 3*rs_c + 1*cs_c, cv1, 3);
+
+		// Store column 2
+		vst1q_lane_f32( c + 0*rs_c + 2*cs_c, cv2, 0);
+		vst1q_lane_f32( c + 1*rs_c + 2*cs_c, cv2, 1);
+		vst1q_lane_f32( c + 2*rs_c + 2*cs_c, cv2, 2);
+		vst1q_lane_f32( c + 3*rs_c + 2*cs_c, cv2, 3);
+
+		// Store column 3
+		vst1q_lane_f32( c + 0*rs_c + 3*cs_c, cv3, 0);
+		vst1q_lane_f32( c + 1*rs_c + 3*cs_c, cv3, 1);
+		vst1q_lane_f32( c + 2*rs_c + 3*cs_c, cv3, 2);
+		vst1q_lane_f32( c + 3*rs_c + 3*cs_c, cv3, 3);
+	}
+}
+
+void bli_dgemm_armv7a_int_4x4
+     (
+       dim_t               k,
+       double*    restrict alpha,
+       double*    restrict a,
+       double*    restrict b,
+       double*    restrict beta,
+       double*    restrict c, inc_t rs_c0, inc_t cs_c0,
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
+     )
+{
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	//uint32_t k_iter = k0 / 4;
+	uint32_t k_left = k % 4;
+	uint32_t rs_c   = rs_c0;
+	uint32_t cs_c   = cs_c0;
+	uint32_t i;
+
+	//void* a_next = bli_auxinfo_next_a( data );
+	//void* b_next = bli_auxinfo_next_b( data );
+
+	register double a0;
+	register double a1;
+	register double a2;
+	register double a3;
+
+	register double A0;
+	register double A1;
+	register double A2;
+	register double A3;
+
+	double b0, b1, b2, b3;
+	double B0, B1, B2, B3;
+
+	double  ab00, ab01, ab02, ab03; 
+	double  ab10, ab11, ab12, ab13; 
+	double  ab20, ab21, ab22, ab23;
+	double  ab30, ab31, ab32, ab33; 
+
+	double* restrict c00, * restrict c01, * restrict c02, * restrict c03; 
+	double* restrict c10, * restrict c11, * restrict c12, * restrict c13;
+	double* restrict c20, * restrict c21, * restrict c22, * restrict c23;
+	double* restrict c30, * restrict c31, * restrict c32, * restrict c33; 
+
+	double* restrict ap = a;
+        double* restrict bp = b; 
+
+	double* restrict Ap = a + 4;
+        double* restrict Bp = b + 4; 
+
+	c00 = (c + 0*rs_c + 0*cs_c); 
+	c10 = (c + 1*rs_c + 0*cs_c); 
+	c20 = (c + 2*rs_c + 0*cs_c); 
+	c30 = (c + 3*rs_c + 0*cs_c); 
+
+	c01 = (c + 0*rs_c + 1*cs_c); 
+	c11 = (c + 1*rs_c + 1*cs_c); 
+	c21 = (c + 2*rs_c + 1*cs_c); 
+	c31 = (c + 3*rs_c + 1*cs_c); 
+
+	c02 = (c + 0*rs_c + 2*cs_c); 
+	c12 = (c + 1*rs_c + 2*cs_c); 
+	c22 = (c + 2*rs_c + 2*cs_c); 
+	c32 = (c + 3*rs_c + 2*cs_c); 
+
+	c03 = (c + 0*rs_c + 3*cs_c); 
+	c13 = (c + 1*rs_c + 3*cs_c); 
+	c23 = (c + 2*rs_c + 3*cs_c); 
+	c33 = (c + 3*rs_c + 3*cs_c); 
+
+	ab00 = 0.0; ab10 = 0.0; ab20 = 0.0; ab30 = 0.0;
+	ab01 = 0.0; ab11 = 0.0; ab21 = 0.0; ab31 = 0.0;
+	ab02 = 0.0; ab12 = 0.0; ab22 = 0.0; ab32 = 0.0;
+	ab03 = 0.0; ab13 = 0.0; ab23 = 0.0; ab33 = 0.0;
+
+	A0 = *(Ap + 0); 
+	A1 = *(Ap + 1); 
+	A2 = *(Ap + 2); 
+	A3 = *(Ap + 3); 
+
+	a0 = *(ap + 0); 
+	a1 = *(ap + 1);
+ 	a2 = *(ap + 2);
+
+	B0 = *(Bp + 0);
+	B1 = *(Bp + 1);
+	B2 = *(Bp + 2);
+	B3 = *(Bp + 3);
+
+	b0 = *(bp + 0);
+	b1 = *(bp + 1);
+	b2 = *(bp + 2);
+
+	double *Aplast = (Ap + 4*(k-k_left)); 
+
+	//for ( i = 0; i < k_iter; ++i ) // Unroll by factor 4.
+	for ( ; Ap != Aplast ; ) // Unroll by factor 4.
+	{ 
+		/* Prefetch */
+		//__asm__ ("pld\t[%0],#100\n\t" : :"r"(Ap) : );
+		__builtin_prefetch( ap + 112 );
+		__builtin_prefetch( Ap + 112 );
+		__builtin_prefetch( bp + 112 );
+		__builtin_prefetch( Bp + 112 );
+		// Iteration 0.
+		ab00 += A0 * B0;
+		a3 = *(ap + 3);
+		ab10 += A1 * B0;
+		b3 = *(bp + 3);
+		ab20 += A2 * B0;
+		ab30 += A3 * B0;
+
+		ab01 += A0 * B1;
+		ab11 += A1 * B1;
+		B0 = *(Bp + 8);  // Prefetch.
+		ab21 += A2 * B1;
+		ab31 += A3 * B1;
+
+		ab02 += A0 * B2;
+		B1 = *(Bp + 9);
+		ab12 += A1 * B2;
+		ab22 += A2 * B2;
+		ab32 += A3 * B2;
+		B2 = *(Bp + 10);
+
+		ab03 += A0 * B3;
+		A0 = *(Ap + 8);  // Prefetch.
+		ab13 += A1 * B3;
+		A1 = *(Ap + 9);  // Prefetch.
+		ab23 += A2 * B3;
+		ab33 += A3 * B3;
+		A2 = *(Ap + 10); // Prefetch.
+
+		// Iteration 1.
+		//__asm__ ("pld\t[%0],#200\n\t" : :"r"(Ap) : );
+		ab00 += a0 * b0;
+		ab10 += a1 * b0;
+		A3 = *(Ap + 11); // Prefetch.
+		ab20 += a2 * b0;
+		ab30 += a3 * b0;
+		B3 = *(Bp + 11);
+
+		ab01 += a0 * b1;
+		b0 = *(bp + 8);
+		ab11 += a1 * b1;
+		ab21 += a2 * b1;
+		ab31 += a3 * b1;
+		b1 = *(bp + 9);
+
+		ab02 += a0 * b2;
+		ab12 += a1 * b2;
+		ab22 += a2 * b2;
+		ab32 += a3 * b2;
+		b2 = *(bp + 10);
+
+		ab03 += a0 * b3;
+		a0 = *(ap + 8); 
+		ab13 += a1 * b3;
+		a1 = *(ap + 9);
+		ab23 += a2 * b3;
+		a2 = *(ap + 10);
+		ab33 += a3 * b3;
+		//a3 = *(ap + 11);
+
+		ap += 8; 
+		Ap += 8; 
+		bp += 8; 
+		Bp += 8; 
+
+	} 
+
+
+	for ( i = 0; i < k_left; ++i ) 
+	{ 
+		a0 = *(ap + 0); 
+		a1 = *(ap + 1);
+		a2 = *(ap + 2);
+		a3 = *(ap + 3);
+
+		b0 = *(bp + 0);
+		b1 = *(bp + 1);
+		b2 = *(bp + 2);
+		b3 = *(bp + 3);
+
+		ab00 += a0 * b0;
+		ab10 += a1 * b0;
+		ab20 += a2 * b0;
+		ab30 += a3 * b0;
+
+		ab01 += a0 * b1;
+		ab11 += a1 * b1;
+		ab21 += a2 * b1;
+		ab31 += a3 * b1;
+
+		ab02 += a0 * b2;
+		ab12 += a1 * b2;
+		ab22 += a2 * b2;
+		ab32 += a3 * b2;
+
+		ab03 += a0 * b3;
+		ab13 += a1 * b3;
+		ab23 += a2 * b3;
+		ab33 += a3 * b3;
+
+		ap += 4; 
+		bp += 4; 
+	} 
+
+	*c00 = *c00 * *beta;
+	*c10 = *c10 * *beta;
+	*c20 = *c20 * *beta;
+	*c30 = *c30 * *beta;
+
+	*c01 = *c01 * *beta;
+	*c11 = *c11 * *beta;
+	*c21 = *c21 * *beta;
+	*c31 = *c31 * *beta;
+
+	*c02 = *c02 * *beta;
+	*c12 = *c12 * *beta;
+	*c22 = *c22 * *beta;
+	*c32 = *c32 * *beta;
+
+	*c03 = *c03 * *beta;
+	*c13 = *c13 * *beta;
+	*c23 = *c23 * *beta;
+	*c33 = *c33 * *beta;
+
+	*c00 += ab00 * *alpha;
+	*c10 += ab10 * *alpha;
+	*c20 += ab20 * *alpha;
+	*c30 += ab30 * *alpha;
+
+	*c01 += ab01 * *alpha;
+	*c11 += ab11 * *alpha;
+	*c21 += ab21 * *alpha;
+	*c31 += ab31 * *alpha;
+
+	*c02 += ab02 * *alpha;
+	*c12 += ab12 * *alpha;
+	*c22 += ab22 * *alpha;
+	*c32 += ab32 * *alpha;
+
+	*c03 += ab03 * *alpha;
+	*c13 += ab13 * *alpha;
+	*c23 += ab23 * *alpha;
+	*c33 += ab33 * *alpha;
+}
+

--- a/src/configs/armv7a/config.cxx
+++ b/src/configs/armv7a/config.cxx
@@ -1,0 +1,23 @@
+#include "config.hpp"
+
+#include "util/cpuid.hpp"
+
+namespace tblis
+{
+
+int armv7a_check()
+{
+    int model, part, features;
+    int vendor = get_cpu_type(model, part, features);
+
+    // Arm64 has full Arm32 compatibility.
+    // if (model != MODEL_ARMV7)
+    // {
+    //     if (get_verbose() >= 1) printf("tblis: armv7a: Not Arm32.\n");
+    //     return -1;
+    // }
+
+    return 1;
+}
+
+}

--- a/src/configs/armv7a/config.hpp
+++ b/src/configs/armv7a/config.hpp
@@ -1,0 +1,42 @@
+#ifndef _TBLIS_CONFIGS_ARMV7A_CONFIG_HPP_
+#define _TBLIS_CONFIGS_ARMV7A_CONFIG_HPP_
+
+#include "configs/config_builder.hpp"
+
+EXTERN_BLIS_GEMM_UKR(bli_sgemm_armv7a_int_4x4);
+EXTERN_BLIS_GEMM_UKR(bli_dgemm_armv7a_int_4x4);
+
+namespace tblis
+{
+
+extern int armv7a_check();
+
+TBLIS_BEGIN_CONFIG(armv7a)
+
+    TBLIS_CONFIG_GEMM_MR(   4,    4, _, _)
+    TBLIS_CONFIG_GEMM_NR(   4,    4, _, _)
+    TBLIS_CONFIG_GEMM_KR(   4,    4, _, _)
+    TBLIS_CONFIG_GEMM_MC( 336,  176, _, _)
+    TBLIS_CONFIG_GEMM_NC( 528,  368, _, _)
+    TBLIS_CONFIG_GEMM_KC(4096, 4096, _, _)
+
+    // TBLIS_CONFIG_M_THREAD_RATIO(_,3,_,_)
+    // TBLIS_CONFIG_N_THREAD_RATIO(_,2,_,_)
+    // TBLIS_CONFIG_MR_MAX_THREAD(_,1,_,_)
+    // TBLIS_CONFIG_NR_MAX_THREAD(_,4,_,_)
+
+    TBLIS_CONFIG_GEMM_WRAP_UKR(bli_sgemm_armv7a_int_4x4,
+                               bli_dgemm_armv7a_int_4x4,
+                               _,
+                               _)
+
+    TBLIS_CONFIG_GEMM_ROW_MAJOR(false, false, _, _)
+    TBLIS_CONFIG_GEMM_FLIP_UKR(true, true, _, _)
+
+    TBLIS_CONFIG_CHECK(armv7a_check)
+
+TBLIS_END_CONFIG
+
+}
+
+#endif

--- a/src/configs/armv7a/config_ker.cxx
+++ b/src/configs/armv7a/config_ker.cxx
@@ -1,0 +1,10 @@
+#include "config.hpp"
+
+#include "util/cpuid.hpp"
+
+namespace tblis
+{
+
+TBLIS_CONFIG_INSTANTIATE(armv7a);
+
+}

--- a/src/configs/armv8a/bli_armv8a_macros.h
+++ b/src/configs/armv8a/bli_armv8a_macros.h
@@ -1,0 +1,15 @@
+// Current used only to support
+//  Apple's twisted label requirements.
+
+#if defined(__APPLE__)
+#define LABEL(str) " LBB_" #str": \n\t"
+#define BEQ(str) "b.eq LBB_" #str" \n\t"
+#define BNE(str) "b.ne LBB_" #str" \n\t"
+#define BRANCH(str) "b LBB_" #str" \n\t"
+#else
+#define LABEL(str) " ." #str": \n\t"
+#define BEQ(str) "b.eq ." #str" \n\t"
+#define BNE(str) "b.ne ." #str" \n\t"
+#define BRANCH(str) "b ." #str" \n\t"
+#endif
+

--- a/src/configs/armv8a/bli_gemm_asm_d6x8.c
+++ b/src/configs/armv8a/bli_gemm_asm_d6x8.c
@@ -1,0 +1,2115 @@
+    /* 
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+
+#include "blis.h"
+#include "bli_armv8a_macros.h"
+
+/*
+   o 4x4 Single precision micro-kernel fully functional.
+   o Runnable on ARMv8, compiled with aarch64 GCC.
+   o Use it together with the armv8 BLIS configuration.
+   o Tested on Juno board. Around 7.3 GFLOPS @ 1.1 GHz. 
+
+   December 2014.
+ 
+ * UPDATE NOVEMBER 2015
+ * Micro-kernel changed to 8x12
+ * Tested on Juno Board. Around  8.1 GFLOPS, 1 x A57 core  @ 1.1 GHz.
+ * Tested on Juno Board. Around 15.9 GFLOPS, 2 x A57 cores @ 1.1 GHz.
+ * Tested on Juno board. Around  3.1 GFLOPS, 1 x A53 core  @ 850 MHz. 
+ * Tested on Juno board. Around 12   GFLOPS, 4 x A53 cores @ 850 MHz.
+*/
+void bli_sgemm_armv8a_asm_8x12
+     (
+       dim_t               k0,
+       float*     restrict alpha,
+       float*     restrict a,
+       float*     restrict b,
+       float*     restrict beta,
+       float*     restrict c, inc_t rs_c0, inc_t cs_c0,
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
+     )
+{
+	void* a_next = bli_auxinfo_next_a( data );
+	void* b_next = bli_auxinfo_next_b( data );
+
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	uint64_t k_iter = k0 / 4;
+	uint64_t k_left = k0 % 4;
+	uint64_t rs_c   = rs_c0;
+	uint64_t cs_c   = cs_c0;
+
+
+__asm__ volatile 
+(
+"                                            \n\t"
+"                                            \n\t"
+" ldr x0,%[aaddr]                            \n\t" // Load address of A. 
+" ldr x1,%[baddr]                            \n\t" // Load address of B.
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+"                                            \n\t"
+" ldr x3,%[a_next]                           \n\t" // Pointer to next block of A.
+" ldr x4,%[b_next]                           \n\t" // Pointer to next pointer of B.
+"                                            \n\t"
+" ldr x5,%[k_iter]                           \n\t" // Number of unrolled iterations (k_iter).
+" ldr x6,%[k_left]                           \n\t" // Number of remaining iterations (k_left).
+"                                            \n\t" 
+" ldr x7,%[alpha]                            \n\t" // Alpha address.      
+" ldr x8,%[beta]                             \n\t" // Beta address.     
+"                                            \n\t" 
+" ldr x9,%[cs_c]                             \n\t" // Load cs_c.
+" lsl x10,x9,#2                              \n\t" // cs_c * sizeof(float) -- AUX.
+"                                            \n\t" 
+" ldr x13,%[rs_c]                            \n\t" // Load rs_c.
+" lsl x14,x13,#2                             \n\t" // rs_c * sizeof(float).
+"                                            \n\t"
+" add x16,x2,x10                             \n\t" //Load address Column 1 of C
+" add x17,x16,x10                            \n\t" //Load address Column 2 of C
+" add x18,x17,x10                            \n\t" //Load address Column 3 of C
+" add x19,x18,x10                            \n\t" //Load address Column 4 of C
+" add x20,x19,x10                            \n\t" //Load address Column 5 of C
+" add x21,x20,x10                            \n\t" //Load address Column 6 of C
+" add x22,x21,x10                            \n\t" //Load address Column 7 of C
+" add x23,x22,x10                            \n\t" //Load address Column 8 of C
+" add x24,x23,x10                            \n\t" //Load address Column 9 of C
+" add x25,x24,x10                            \n\t" //Load address Column 10 of C
+" add x26,x25,x10                            \n\t" //Load address Column 11 of C
+"                                            \n\t"
+" prfm pldl1keep,[x2]                        \n\t" // Prefetch c.
+" prfm pldl1keep,[x16]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x17]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x18]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x19]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x20]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x21]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x22]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x23]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x24]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x25]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x26]                       \n\t" // Prefetch c.
+"                                            \n\t"
+" dup  v8.4s, wzr                            \n\t" // Vector for accummulating column 0
+" prfm    PLDL1KEEP, [x1, #192]              \n\t" 
+" dup  v9.4s, wzr                            \n\t" // Vector for accummulating column 0
+" prfm    PLDL1KEEP, [x1, #256]              \n\t"
+" dup  v10.4s, wzr                           \n\t" // Vector for accummulating column 1
+" prfm    PLDL1KEEP, [x1, #320]              \n\t"
+" dup  v11.4s, wzr                           \n\t" // Vector for accummulating column 1
+" dup  v12.4s, wzr                           \n\t" // Vector for accummulating column 2 
+" dup  v13.4s, wzr                           \n\t" // Vector for accummulating column 2
+"                                            \n\t"
+" dup  v14.4s, wzr                           \n\t" // Vector for accummulating column 3
+" prfm    PLDL1KEEP, [x0, #128]              \n\t"
+" dup  v15.4s, wzr                           \n\t" // Vector for accummulating column 3
+" prfm    PLDL1KEEP, [x0, #192]              \n\t"
+" dup  v16.4s, wzr                           \n\t" // Vector for accummulating column 4
+" dup  v17.4s, wzr                           \n\t" // Vector for accummulating column 4
+" dup  v18.4s, wzr                           \n\t" // Vector for accummulating column 5 
+" dup  v19.4s, wzr                           \n\t" // Vector for accummulating column 5
+"                                            \n\t"
+" dup  v20.4s, wzr                           \n\t" // Vector for accummulating column 6 
+" dup  v21.4s, wzr                           \n\t" // Vector for accummulating column 6
+" dup  v22.4s, wzr                           \n\t" // Vector for accummulating column 7
+" dup  v23.4s, wzr                           \n\t" // Vector for accummulating column 7
+" dup  v24.4s, wzr                           \n\t" // Vector for accummulating column 8 
+" dup  v25.4s, wzr                           \n\t" // Vector for accummulating column 8
+"                                            \n\t"
+" dup  v26.4s, wzr                           \n\t" // Vector for accummulating column 9 
+" dup  v27.4s, wzr                           \n\t" // Vector for accummulating column 9
+" dup  v28.4s, wzr                           \n\t" // Vector for accummulating column 10
+" dup  v29.4s, wzr                           \n\t" // Vector for accummulating column 10
+" dup  v30.4s, wzr                           \n\t" // Vector for accummulating column 11 
+" dup  v31.4s, wzr                           \n\t" // Vector for accummulating column 11
+"                                            \n\t"
+" cmp x5,#0                                  \n\t" // If k_iter == 0, jump to k_left.
+BEQ(SCONSIDERKLEFT)
+"                                            \n\t"
+" ldr q0, [x0]                               \n\t"
+" ldr q1, [x0, #16]                          \n\t" // Load a
+"                                            \n\t"
+" ldr q2, [x1]                               \n\t" // Load b
+" ldr q3, [x1, #16]                          \n\t"
+" ldr q4, [x1, #32]                          \n\t"
+"                                            \n\t"
+" add x0, x0, #32                            \n\t" //update address of A
+" add x1, x1, #48                            \n\t" //update address of B
+"                                            \n\t"
+" cmp x5,1                                   \n\t" // If there is just one k_iter, jump to that one. 
+BEQ(SLASTITER) // (as loop is do-while-like).
+"                                            \n\t"
+LABEL(SLOOPKITER) // Body of the k_iter loop.
+"                                            \n\t"
+" ldr q5, [x0]                               \n\t"
+" fmla v8.4s, v0.4s,v2.s[0]                  \n\t" // Accummulate.
+" fmla v9.4s, v1.4s,v2.s[0]                  \n\t" // Accummulate.
+" ldr q6, [x0, #16]                          \n\t"
+" fmla v10.4s,v0.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v11.4s,v1.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v12.4s,v0.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v13.4s,v1.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v14.4s,v0.4s,v2.s[3]                  \n\t" // Accummulate.
+" fmla v15.4s,v1.4s,v2.s[3]                  \n\t" // Accummulate.
+" ldr q2, [x1]                               \n\t"
+"                                            \n\t"
+" fmla v16.4s,v0.4s,v3.s[0]                  \n\t" // Accummulate.
+" prfm    PLDL1KEEP, [x1, #336]              \n\t" 
+" fmla v17.4s,v1.4s,v3.s[0]                  \n\t" // Accummulate.
+" prfm    PLDL1KEEP, [x1, #400]              \n\t" 
+" fmla v18.4s,v0.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v19.4s,v1.4s,v3.s[1]                  \n\t" // Accummulate.
+" prfm    PLDL1KEEP, [x1, #464]              \n\t" 
+" fmla v20.4s,v0.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v21.4s,v1.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v22.4s,v0.4s,v3.s[3]                  \n\t" // Accummulate.
+" fmla v23.4s,v1.4s,v3.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v0.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v26.4s,v0.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v28.4s,v0.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v30.4s,v0.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q3, [x1, #16]                          \n\t"
+"                                            \n\t"
+" fmla v25.4s,v1.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v27.4s,v1.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v29.4s,v1.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v31.4s,v1.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q4, [x1, #32]                          \n\t"
+"                                            \n\t" //End It 1
+"                                            \n\t"
+" ldr q0, [x0, #32]                          \n\t"
+" fmla v8.4s,v5.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v9.4s,v6.4s,v2.s[0]                   \n\t" // Accummulate.
+" ldr q1, [x0, #48]                          \n\t"
+" fmla v10.4s,v5.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v11.4s,v6.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v12.4s,v5.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v13.4s,v6.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v14.4s,v5.4s,v2.s[3]                  \n\t" // Accummulate.
+" fmla v15.4s,v6.4s,v2.s[3]                  \n\t" // Accummulate.
+" ldr q2, [x1, #48]                          \n\t"
+"                                            \n\t"
+" fmla v16.4s,v5.4s,v3.s[0]                  \n\t" // Accummulate.
+" prfm    PLDL1KEEP, [x0, #224]              \n\t"
+" fmla v17.4s,v6.4s,v3.s[0]                  \n\t" // Accummulate.
+" prfm    PLDL1KEEP, [x0, #288]              \n\t"
+" fmla v18.4s,v5.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v19.4s,v6.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v20.4s,v5.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v21.4s,v6.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v22.4s,v5.4s,v3.s[3]                  \n\t" // Accummulate.
+" fmla v23.4s,v6.4s,v3.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v5.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v26.4s,v5.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v28.4s,v5.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v30.4s,v5.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q3, [x1, #64]                          \n\t"
+"                                            \n\t"
+" fmla v25.4s,v6.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v27.4s,v6.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v29.4s,v6.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v31.4s,v6.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q4, [x1, #80]                          \n\t"
+"                                            \n\t" //End It 2
+"                                            \n\t"
+" ldr q5, [x0, #64]                          \n\t"
+" fmla v8.4s,v0.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v9.4s,v1.4s,v2.s[0]                   \n\t" // Accummulate.
+" ldr q6, [x0, #80]                          \n\t"
+" fmla v10.4s,v0.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v11.4s,v1.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v12.4s,v0.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v13.4s,v1.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v14.4s,v0.4s,v2.s[3]                  \n\t" // Accummulate.
+" fmla v15.4s,v1.4s,v2.s[3]                  \n\t" // Accummulate.
+" ldr q2, [x1, #96]                          \n\t"
+"                                            \n\t"
+" fmla v16.4s,v0.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v17.4s,v1.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v18.4s,v0.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v19.4s,v1.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v20.4s,v0.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v21.4s,v1.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v22.4s,v0.4s,v3.s[3]                  \n\t" // Accummulate.
+" fmla v23.4s,v1.4s,v3.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v0.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v26.4s,v0.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v28.4s,v0.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v30.4s,v0.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q3, [x1, #112]                         \n\t"
+"                                            \n\t"
+" fmla v25.4s,v1.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v27.4s,v1.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v29.4s,v1.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v31.4s,v1.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q4, [x1, #128]                         \n\t"
+"                                            \n\t" //End It 3
+"                                            \n\t"
+" ldr q0, [x0, #96]                          \n\t"
+" fmla v8.4s,v5.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v9.4s,v6.4s,v2.s[0]                   \n\t" // Accummulate.
+" ldr q1, [x0, #112]                         \n\t"
+" fmla v10.4s,v5.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v11.4s,v6.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v12.4s,v5.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v13.4s,v6.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v14.4s,v5.4s,v2.s[3]                  \n\t" // Accummulate.
+" fmla v15.4s,v6.4s,v2.s[3]                  \n\t" // Accummulate.
+" ldr q2, [x1, #144]                         \n\t"
+"                                            \n\t"
+" fmla v16.4s,v5.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v17.4s,v6.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v18.4s,v5.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v19.4s,v6.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v20.4s,v5.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v21.4s,v6.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v22.4s,v5.4s,v3.s[3]                  \n\t" // Accummulate.
+" fmla v23.4s,v6.4s,v3.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v5.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v26.4s,v5.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v28.4s,v5.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v30.4s,v5.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q3, [x1, #160]                         \n\t"
+"                                            \n\t"
+" fmla v25.4s,v6.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v27.4s,v6.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v29.4s,v6.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v31.4s,v6.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q4, [x1, #176]                         \n\t"
+" add x1, x1, #192                           \n\t"
+" add x0, x0, #128                           \n\t"
+"                                            \n\t" //End It 4
+" sub x5,x5,1                                \n\t" // i-=1.
+" cmp x5,1                                   \n\t" // Iterate again if we are not in k_iter == 1.
+BNE(SLOOPKITER)
+"                                            \n\t" 
+LABEL(SLASTITER) // Last iteration of k_iter loop.
+"                                            \n\t" 
+"                                            \n\t"
+" ldr q5, [x0]                               \n\t"
+" fmla v8.4s,v0.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v9.4s,v1.4s,v2.s[0]                   \n\t" // Accummulate.
+" ldr q6, [x0, #16]                          \n\t"
+" fmla v10.4s,v0.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v11.4s,v1.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v12.4s,v0.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v13.4s,v1.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v14.4s,v0.4s,v2.s[3]                  \n\t" // Accummulate.
+" fmla v15.4s,v1.4s,v2.s[3]                  \n\t" // Accummulate.
+" ldr q2, [x1]                               \n\t"
+"                                            \n\t"
+" fmla v16.4s,v0.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v17.4s,v1.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v18.4s,v0.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v19.4s,v1.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v20.4s,v0.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v21.4s,v1.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v22.4s,v0.4s,v3.s[3]                  \n\t" // Accummulate.
+" fmla v23.4s,v1.4s,v3.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v0.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v26.4s,v0.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v28.4s,v0.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v30.4s,v0.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q3, [x1, #16]                          \n\t"
+"                                            \n\t"
+" fmla v25.4s,v1.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v27.4s,v1.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v29.4s,v1.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v31.4s,v1.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q4, [x1, #32]                          \n\t"
+"                                            \n\t" //End It 1
+"                                            \n\t"
+" ldr q0, [x0, #32]                          \n\t"
+" fmla v8.4s,v5.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v9.4s,v6.4s,v2.s[0]                   \n\t" // Accummulate.
+" ldr q1, [x0, #48]                          \n\t"
+" fmla v10.4s,v5.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v11.4s,v6.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v12.4s,v5.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v13.4s,v6.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v14.4s,v5.4s,v2.s[3]                  \n\t" // Accummulate.
+" fmla v15.4s,v6.4s,v2.s[3]                  \n\t" // Accummulate.
+" ldr q2, [x1, #48]                          \n\t"
+"                                            \n\t"
+" fmla v16.4s,v5.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v17.4s,v6.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v18.4s,v5.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v19.4s,v6.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v20.4s,v5.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v21.4s,v6.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v22.4s,v5.4s,v3.s[3]                  \n\t" // Accummulate.
+" fmla v23.4s,v6.4s,v3.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v5.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v26.4s,v5.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v28.4s,v5.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v30.4s,v5.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q3, [x1, #64]                          \n\t"
+"                                            \n\t"
+" fmla v25.4s,v6.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v27.4s,v6.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v29.4s,v6.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v31.4s,v6.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q4, [x1, #80]                          \n\t"
+"                                            \n\t" //End It 2
+"                                            \n\t"
+" ldr q5, [x0, #64]                          \n\t"
+" fmla v8.4s,v0.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v9.4s,v1.4s,v2.s[0]                   \n\t" // Accummulate.
+" ldr q6, [x0, #80]                          \n\t"
+" fmla v10.4s,v0.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v11.4s,v1.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v12.4s,v0.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v13.4s,v1.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v14.4s,v0.4s,v2.s[3]                  \n\t" // Accummulate.
+" fmla v15.4s,v1.4s,v2.s[3]                  \n\t" // Accummulate.
+" ldr q2, [x1, #96]                          \n\t"
+"                                            \n\t"
+" fmla v16.4s,v0.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v17.4s,v1.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v18.4s,v0.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v19.4s,v1.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v20.4s,v0.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v21.4s,v1.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v22.4s,v0.4s,v3.s[3]                  \n\t" // Accummulate.
+" fmla v23.4s,v1.4s,v3.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v0.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v26.4s,v0.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v28.4s,v0.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v30.4s,v0.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q3, [x1, #112]                         \n\t"
+"                                            \n\t"
+" fmla v25.4s,v1.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v27.4s,v1.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v29.4s,v1.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v31.4s,v1.4s,v4.s[3]                  \n\t" // Accummulate.
+" ldr q4, [x1, #128]                         \n\t"
+"                                            \n\t" //End It 3
+"                                            \n\t"
+" fmla v8.4s,v5.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v9.4s,v6.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v10.4s,v5.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v11.4s,v6.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v12.4s,v5.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v13.4s,v6.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v14.4s,v5.4s,v2.s[3]                  \n\t" // Accummulate.
+" fmla v15.4s,v6.4s,v2.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v16.4s,v5.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v17.4s,v6.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v18.4s,v5.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v19.4s,v6.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v20.4s,v5.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v21.4s,v6.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v22.4s,v5.4s,v3.s[3]                  \n\t" // Accummulate.
+" fmla v23.4s,v6.4s,v3.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v5.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v26.4s,v5.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v28.4s,v5.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v30.4s,v5.4s,v4.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v25.4s,v6.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v27.4s,v6.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v29.4s,v6.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v31.4s,v6.4s,v4.s[3]                  \n\t" // Accummulate.
+" add x1, x1, #144                           \n\t"
+" add x0, x0, #96                            \n\t"
+"                                            \n\t" //End It 4
+"                                            \n\t"
+LABEL(SCONSIDERKLEFT)
+" cmp x6,0                                   \n\t" // If k_left == 0, we are done.
+BEQ(SPOSTACCUM) // else, we enter the k_left loop.
+"                                            \n\t"
+LABEL(SLOOPKLEFT) // Body of the left iterations
+"                                            \n\t"
+" ldr q0, [x0],#16                           \n\t"
+" ldr q1, [x0],#16                           \n\t" // Load a
+"                                            \n\t"
+" ldr q2, [x1],#16                           \n\t" // Load b
+" ldr q3, [x1],#16                           \n\t"
+" ldr q4, [x1],#16                           \n\t"
+"                                            \n\t"
+" sub x6,x6,1                                \n\t" // i = i-1.
+"                                            \n\t"
+" fmla v8.4s,v0.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v9.4s,v1.4s,v2.s[0]                   \n\t" // Accummulate.
+" fmla v10.4s,v0.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v11.4s,v1.4s,v2.s[1]                  \n\t" // Accummulate.
+" fmla v12.4s,v0.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v13.4s,v1.4s,v2.s[2]                  \n\t" // Accummulate.
+" fmla v14.4s,v0.4s,v2.s[3]                  \n\t" // Accummulate.
+" fmla v15.4s,v1.4s,v2.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v16.4s,v0.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v17.4s,v1.4s,v3.s[0]                  \n\t" // Accummulate.
+" fmla v18.4s,v0.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v19.4s,v1.4s,v3.s[1]                  \n\t" // Accummulate.
+" fmla v20.4s,v0.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v21.4s,v1.4s,v3.s[2]                  \n\t" // Accummulate.
+" fmla v22.4s,v0.4s,v3.s[3]                  \n\t" // Accummulate.
+" fmla v23.4s,v1.4s,v3.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v0.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v26.4s,v0.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v28.4s,v0.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v30.4s,v0.4s,v4.s[3]                  \n\t" // Accummulate.
+" fmla v25.4s,v1.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v27.4s,v1.4s,v4.s[1]                  \n\t" // Accummulate.
+" fmla v29.4s,v1.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v31.4s,v1.4s,v4.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" cmp x6,0                                   \n\t" // Iterate again.
+BNE(SLOOPKLEFT) // if i!=0.
+"                                            \n\t"
+LABEL(SPOSTACCUM)
+"                                            \n\t"
+" ld1r {v6.4s},[x7]                          \n\t" // Load alpha.
+" ld1r {v7.4s},[x8]                          \n\t" // Load beta
+"                                            \n\t"
+" cmp x13,#1                                 \n\t" // If rs_c != 1 (column-major)
+BNE(SGENSTORED)
+"                                            \n\t"
+LABEL(SCOLSTORED) // C is column-major.
+"                                            \n\t"
+" dup  v0.4s, wzr                            \n\t"
+" dup  v1.4s, wzr                            \n\t"
+" dup  v2.4s, wzr                            \n\t"
+" dup  v3.4s, wzr                            \n\t"
+" dup  v4.4s, wzr                            \n\t"
+" dup  v5.4s, wzr                            \n\t"
+"                                            \n\t"
+" fcmp s7,#0.0                               \n\t"
+BEQ(SBETAZEROCOLSTOREDS1) // Taking care of the beta==0 case.
+"                                            \n\t"
+" ldr q0, [x2]                               \n\t" //Load column 0 of C
+" ldr q1, [x2, #16]                          \n\t"
+" ldr q2, [x16]                              \n\t" //Load column 1 of C
+" ldr q3, [x16, #16]                         \n\t"
+" ldr q4, [x17]                              \n\t" //Load column 2 of C
+" ldr q5, [x17, #16]                         \n\t"
+"                                            \n\t"
+" fmul v0.4s,v0.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v1.4s,v1.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v2.4s,v2.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v3.4s,v3.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v4.4s,v4.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v5.4s,v5.4s,v7.s[0]                   \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(SBETAZEROCOLSTOREDS1)
+"                                            \n\t"
+" fmla v0.4s,v8.4s,v6.s[0]                   \n\t" // Scale by alpha
+" fmla v1.4s,v9.4s,v6.s[0]                   \n\t" // Scale by alpha
+" fmla v2.4s,v10.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v3.4s,v11.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v4.4s,v12.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v5.4s,v13.4s,v6.s[0]                  \n\t" // Scale by alpha
+"                                            \n\t"
+" str q0, [x2]                               \n\t" //Store column 0 of C
+" str q1, [x2, #16]                          \n\t"
+" str q2, [x16]                              \n\t" //Store column 1 of C
+" str q3, [x16, #16]                         \n\t"
+" str q4, [x17]                              \n\t" //Store column 2 of C
+" str q5, [x17, #16]                         \n\t"
+"                                            \n\t"
+" dup  v8.4s, wzr                            \n\t"
+" dup  v9.4s, wzr                            \n\t"
+" dup  v10.4s, wzr                           \n\t"
+" dup  v11.4s, wzr                           \n\t"
+" dup  v12.4s, wzr                           \n\t"
+" dup  v13.4s, wzr                           \n\t"
+"                                            \n\t"
+" fcmp s7,#0.0                               \n\t"
+BEQ(SBETAZEROCOLSTOREDS2) // Taking care of the beta==0 case.
+"                                            \n\t"
+" ldr q8, [x18]                              \n\t" //Load column 3 of C
+" ldr q9, [x18, #16]                         \n\t"
+" ldr q10, [x19]                             \n\t" //Load column 4 of C
+" ldr q11, [x19, #16]                        \n\t"
+" ldr q12, [x20]                             \n\t" //Load column 5 of C
+" ldr q13, [x20, #16]                        \n\t"
+"                                            \n\t"
+" fmul v8.4s, v8.4s, v7.s[0]                 \n\t" // Scale by beta
+" fmul v9.4s, v9.4s, v7.s[0]                 \n\t" // Scale by beta
+" fmul v10.4s,v10.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v11.4s,v11.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v12.4s,v12.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v13.4s,v13.4s,v7.s[0]                 \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(SBETAZEROCOLSTOREDS2)
+"                                            \n\t"
+" fmla v8.4s, v14.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v9.4s, v15.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v10.4s,v16.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v11.4s,v17.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v12.4s,v18.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v13.4s,v19.4s,v6.s[0]                 \n\t" // Scale by alpha
+"                                            \n\t"
+" str q8, [x18]                              \n\t" //Store column 3 of C
+" str q9, [x18, #16]                         \n\t"
+" str q10, [x19]                             \n\t" //Store column 4 of C
+" str q11, [x19, #16]                        \n\t"
+" str q12, [x20]                             \n\t" //Store column 5 of C
+" str q13, [x20, #16]                        \n\t"
+"                                            \n\t"
+" dup  v0.4s, wzr                            \n\t"
+" dup  v1.4s, wzr                            \n\t"
+" dup  v2.4s, wzr                            \n\t"
+" dup  v3.4s, wzr                            \n\t"
+" dup  v4.4s, wzr                            \n\t"
+" dup  v5.4s, wzr                            \n\t"
+"                                            \n\t"
+" fcmp s7,#0.0                               \n\t"
+BEQ(SBETAZEROCOLSTOREDS3) // Taking care of the beta==0 case.
+"                                            \n\t"
+" ldr q0, [x21]                              \n\t" //Load column 6 of C
+" ldr q1, [x21, #16]                         \n\t"
+" ldr q2, [x22]                              \n\t" //Load column 7 of C
+" ldr q3, [x22, #16]                         \n\t"
+" ldr q4, [x23]                              \n\t" //Load column 8 of C
+" ldr q5, [x23, #16]                         \n\t"
+"                                            \n\t"
+" fmul v0.4s,v0.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v1.4s,v1.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v2.4s,v2.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v3.4s,v3.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v4.4s,v4.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v5.4s,v5.4s,v7.s[0]                   \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(SBETAZEROCOLSTOREDS3)
+"                                            \n\t"
+" fmla v0.4s,v20.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v1.4s,v21.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v2.4s,v22.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v3.4s,v23.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v4.4s,v24.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v5.4s,v25.4s,v6.s[0]                  \n\t" // Scale by alpha
+"                                            \n\t"
+" str q0, [x21]                              \n\t" //Store column 6 of C
+" str q1, [x21, #16]                         \n\t"
+" str q2, [x22]                              \n\t" //Store column 7 of C
+" str q3, [x22, #16]                         \n\t"
+" str q4, [x23]                              \n\t" //Store column 8 of C
+" str q5, [x23, #16]                         \n\t"
+"                                            \n\t"
+" dup  v8.4s, wzr                            \n\t"
+" dup  v9.4s, wzr                            \n\t"
+" dup  v10.4s, wzr                            \n\t"
+" dup  v11.4s, wzr                            \n\t"
+" dup  v12.4s, wzr                            \n\t"
+" dup  v13.4s, wzr                            \n\t"
+"                                            \n\t"
+" fcmp s7,#0.0                               \n\t"
+BEQ(SBETAZEROCOLSTOREDS4) // Taking care of the beta==0 case.
+"                                            \n\t"
+" ldr q8, [x24]                              \n\t" //Load column 9 of C
+" ldr q9, [x24, #16]                         \n\t"
+" ldr q10, [x25]                             \n\t" //Load column 10 of C
+" ldr q11, [x25, #16]                        \n\t"
+" ldr q12, [x26]                             \n\t" //Load column 11 of C
+" ldr q13, [x26, #16]                        \n\t"
+"                                            \n\t"
+" fmul v8.4s, v8.4s, v7.s[0]                 \n\t" // Scale by beta
+" fmul v9.4s, v9.4s, v7.s[0]                 \n\t" // Scale by beta
+" fmul v10.4s,v10.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v11.4s,v11.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v12.4s,v12.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v13.4s,v13.4s,v7.s[0]                 \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(SBETAZEROCOLSTOREDS4)
+"                                            \n\t"
+" prfm pldl2keep,[x3]                        \n\t"
+" prfm pldl2keep,[x4]                        \n\t"
+"                                            \n\t"
+" fmla v8.4s, v26.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v9.4s, v27.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v10.4s,v28.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v11.4s,v29.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v12.4s,v30.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v13.4s,v31.4s,v6.s[0]                 \n\t" // Scale by alpha
+"                                            \n\t"
+" str q8, [x24]                              \n\t" //Store column 9 of C
+" str q9, [x24, #16]                         \n\t"
+" str q10, [x25]                             \n\t" //Store column 10 of C
+" str q11, [x25, #16]                        \n\t"
+" str q12, [x26]                             \n\t" //Store column 11 of C
+" str q13, [x26, #16]                        \n\t"
+"                                            \n\t"
+"                                            \n\t"
+BRANCH(SEND) // Done (TODO: this obviously needs to be moved down to remove jump).
+"                                            \n\t"
+"                                            \n\t"
+LABEL(SGENSTORED) // C is general-stride stored.
+"                                            \n\t"
+"                                            \n\t"
+" dup  v0.4s, wzr                            \n\t"
+" dup  v1.4s, wzr                            \n\t"
+" dup  v2.4s, wzr                            \n\t"
+" dup  v3.4s, wzr                            \n\t"
+" dup  v4.4s, wzr                            \n\t"
+" dup  v5.4s, wzr                            \n\t"
+"                                            \n\t"
+" fcmp s7,#0.0                               \n\t"
+BEQ(SBETAZEROGENSTOREDS1) // Taking care of the beta==0 case.
+"                                            \n\t"
+" mov x27, x2                                \n\t"
+"                                            \n\t"
+" ld1 {v0.s}[0],[x27],x14                    \n\t" // Load c00  into quad and increment by rs_c.
+" ld1 {v0.s}[1],[x27],x14                    \n\t" // Load c01  into quad and increment by rs_c.
+" ld1 {v0.s}[2],[x27],x14                    \n\t" // Load c02  into quad and increment by rs_c.
+" ld1 {v0.s}[3],[x27],x14                    \n\t" // Load c03  into quad and increment by rs_c.
+" ld1 {v1.s}[0],[x27],x14                    \n\t" // Load c04  into quad and increment by rs_c.
+" ld1 {v1.s}[1],[x27],x14                    \n\t" // Load c05  into quad and increment by rs_c.
+" ld1 {v1.s}[2],[x27],x14                    \n\t" // Load c06  into quad and increment by rs_c.
+" ld1 {v1.s}[3],[x27],x14                    \n\t" // Load c07  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x16                               \n\t"
+"                                            \n\t"
+" ld1 {v2.s}[0],[x27],x14                    \n\t" // Load c10  into quad and increment by rs_c.
+" ld1 {v2.s}[1],[x27],x14                    \n\t" // Load c11  into quad and increment by rs_c.
+" ld1 {v2.s}[2],[x27],x14                    \n\t" // Load c12  into quad and increment by rs_c.
+" ld1 {v2.s}[3],[x27],x14                    \n\t" // Load c13  into quad and increment by rs_c.
+" ld1 {v3.s}[0],[x27],x14                    \n\t" // Load c14  into quad and increment by rs_c.
+" ld1 {v3.s}[1],[x27],x14                    \n\t" // Load c15  into quad and increment by rs_c.
+" ld1 {v3.s}[2],[x27],x14                    \n\t" // Load c16  into quad and increment by rs_c.
+" ld1 {v3.s}[3],[x27],x14                    \n\t" // Load c17  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x17                               \n\t"
+"                                            \n\t"
+" ld1 {v4.s}[0],[x27],x14                    \n\t" // Load c20  into quad and increment by rs_c.
+" ld1 {v4.s}[1],[x27],x14                    \n\t" // Load c21  into quad and increment by rs_c.
+" ld1 {v4.s}[2],[x27],x14                    \n\t" // Load c22  into quad and increment by rs_c.
+" ld1 {v4.s}[3],[x27],x14                    \n\t" // Load c23  into quad and increment by rs_c.
+" ld1 {v5.s}[0],[x27],x14                    \n\t" // Load c24  into quad and increment by rs_c.
+" ld1 {v5.s}[1],[x27],x14                    \n\t" // Load c25  into quad and increment by rs_c.
+" ld1 {v5.s}[2],[x27],x14                    \n\t" // Load c26  into quad and increment by rs_c.
+" ld1 {v5.s}[3],[x27],x14                    \n\t" // Load c27  into quad and increment by rs_c.
+"                                            \n\t"
+" fmul v0.4s,v0.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v1.4s,v1.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v2.4s,v2.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v3.4s,v3.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v4.4s,v4.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v5.4s,v5.4s,v7.s[0]                   \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(SBETAZEROGENSTOREDS1)
+"                                            \n\t"
+" fmla v0.4s, v8.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v1.4s, v9.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v2.4s,v10.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v3.4s,v11.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v4.4s,v12.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v5.4s,v13.4s,v6.s[0]                  \n\t" // Scale by alpha
+"                                            \n\t"
+" mov x27, x2                                \n\t"
+"                                            \n\t"
+" st1 {v0.s}[0],[x27],x14                    \n\t" // Store c00  into quad and increment by rs_c.
+" st1 {v0.s}[1],[x27],x14                    \n\t" // Store c01  into quad and increment by rs_c.
+" st1 {v0.s}[2],[x27],x14                    \n\t" // Store c02  into quad and increment by rs_c.
+" st1 {v0.s}[3],[x27],x14                    \n\t" // Store c03  into quad and increment by rs_c.
+" st1 {v1.s}[0],[x27],x14                    \n\t" // Store c04  into quad and increment by rs_c.
+" st1 {v1.s}[1],[x27],x14                    \n\t" // Store c05  into quad and increment by rs_c.
+" st1 {v1.s}[2],[x27],x14                    \n\t" // Store c06  into quad and increment by rs_c.
+" st1 {v1.s}[3],[x27],x14                    \n\t" // Store c07  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x16                               \n\t"
+"                                            \n\t"
+" st1 {v2.s}[0],[x27],x14                    \n\t" // Store c10  into quad and increment by rs_c.
+" st1 {v2.s}[1],[x27],x14                    \n\t" // Store c11  into quad and increment by rs_c.
+" st1 {v2.s}[2],[x27],x14                    \n\t" // Store c12  into quad and increment by rs_c.
+" st1 {v2.s}[3],[x27],x14                    \n\t" // Store c13  into quad and increment by rs_c.
+" st1 {v3.s}[0],[x27],x14                    \n\t" // Store c14  into quad and increment by rs_c.
+" st1 {v3.s}[1],[x27],x14                    \n\t" // Store c15  into quad and increment by rs_c.
+" st1 {v3.s}[2],[x27],x14                    \n\t" // Store c16  into quad and increment by rs_c.
+" st1 {v3.s}[3],[x27],x14                    \n\t" // Store c17  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x17                               \n\t"
+"                                            \n\t"
+" st1 {v4.s}[0],[x27],x14                    \n\t" // Store c20  into quad and increment by rs_c.
+" st1 {v4.s}[1],[x27],x14                    \n\t" // Store c21  into quad and increment by rs_c.
+" st1 {v4.s}[2],[x27],x14                    \n\t" // Store c22  into quad and increment by rs_c.
+" st1 {v4.s}[3],[x27],x14                    \n\t" // Store c23  into quad and increment by rs_c.
+" st1 {v5.s}[0],[x27],x14                    \n\t" // Store c24  into quad and increment by rs_c.
+" st1 {v5.s}[1],[x27],x14                    \n\t" // Store c25  into quad and increment by rs_c.
+" st1 {v5.s}[2],[x27],x14                    \n\t" // Store c26  into quad and increment by rs_c.
+" st1 {v5.s}[3],[x27],x14                    \n\t" // Store c27  into quad and increment by rs_c.
+"                                            \n\t"
+" dup  v8.4s, wzr                            \n\t"
+" dup  v9.4s, wzr                            \n\t"
+" dup  v10.4s, wzr                           \n\t"
+" dup  v11.4s, wzr                           \n\t"
+" dup  v12.4s, wzr                           \n\t"
+" dup  v13.4s, wzr                           \n\t"
+"                                            \n\t"
+" fcmp s7,#0.0                               \n\t"
+BEQ(SBETAZEROGENSTOREDS2) // Taking care of the beta==0 case.
+"                                            \n\t"
+" mov x27, x18                               \n\t"
+"                                            \n\t"
+" ld1 {v8.s}[0],[x27],x14                    \n\t" // Load c30  into quad and increment by rs_c.
+" ld1 {v8.s}[1],[x27],x14                    \n\t" // Load c31  into quad and increment by rs_c.
+" ld1 {v8.s}[2],[x27],x14                    \n\t" // Load c32  into quad and increment by rs_c.
+" ld1 {v8.s}[3],[x27],x14                    \n\t" // Load c33  into quad and increment by rs_c.
+" ld1 {v9.s}[0],[x27],x14                    \n\t" // Load c34  into quad and increment by rs_c.
+" ld1 {v9.s}[1],[x27],x14                    \n\t" // Load c35  into quad and increment by rs_c.
+" ld1 {v9.s}[2],[x27],x14                    \n\t" // Load c36  into quad and increment by rs_c.
+" ld1 {v9.s}[3],[x27],x14                    \n\t" // Load c37  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x19                               \n\t"
+"                                            \n\t"
+" ld1 {v10.s}[0],[x27],x14                   \n\t" // Load c40  into quad and increment by rs_c.
+" ld1 {v10.s}[1],[x27],x14                   \n\t" // Load c41  into quad and increment by rs_c.
+" ld1 {v10.s}[2],[x27],x14                   \n\t" // Load c42  into quad and increment by rs_c.
+" ld1 {v10.s}[3],[x27],x14                   \n\t" // Load c43  into quad and increment by rs_c.
+" ld1 {v11.s}[0],[x27],x14                   \n\t" // Load c44  into quad and increment by rs_c.
+" ld1 {v11.s}[1],[x27],x14                   \n\t" // Load c45  into quad and increment by rs_c.
+" ld1 {v11.s}[2],[x27],x14                   \n\t" // Load c46  into quad and increment by rs_c.
+" ld1 {v11.s}[3],[x27],x14                   \n\t" // Load c47  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x20                               \n\t"
+"                                            \n\t"
+" ld1 {v12.s}[0],[x27],x14                   \n\t" // Load c50  into quad and increment by rs_c.
+" ld1 {v12.s}[1],[x27],x14                   \n\t" // Load c51  into quad and increment by rs_c.
+" ld1 {v12.s}[2],[x27],x14                   \n\t" // Load c52  into quad and increment by rs_c.
+" ld1 {v12.s}[3],[x27],x14                   \n\t" // Load c53  into quad and increment by rs_c.
+" ld1 {v13.s}[0],[x27],x14                   \n\t" // Load c54  into quad and increment by rs_c.
+" ld1 {v13.s}[1],[x27],x14                   \n\t" // Load c55  into quad and increment by rs_c.
+" ld1 {v13.s}[2],[x27],x14                   \n\t" // Load c56  into quad and increment by rs_c.
+" ld1 {v13.s}[3],[x27],x14                   \n\t" // Load c57  into quad and increment by rs_c.
+"                                            \n\t"
+" fmul v8.4s, v8.4s, v7.s[0]                 \n\t" // Scale by beta
+" fmul v9.4s, v9.4s, v7.s[0]                 \n\t" // Scale by beta
+" fmul v10.4s,v10.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v11.4s,v11.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v12.4s,v12.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v13.4s,v13.4s,v7.s[0]                 \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(SBETAZEROGENSTOREDS2)
+"                                            \n\t"
+" fmla v8.4s, v14.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v9.4s, v15.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v10.4s,v16.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v11.4s,v17.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v12.4s,v18.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v13.4s,v19.4s,v6.s[0]                 \n\t" // Scale by alpha
+"                                            \n\t"
+" mov x27, x18                               \n\t"
+"                                            \n\t"
+" st1 {v8.s}[0],[x27],x14                    \n\t" // Store c30  into quad and increment by rs_c.
+" st1 {v8.s}[1],[x27],x14                    \n\t" // Store c31  into quad and increment by rs_c.
+" st1 {v8.s}[2],[x27],x14                    \n\t" // Store c32  into quad and increment by rs_c.
+" st1 {v8.s}[3],[x27],x14                    \n\t" // Store c33  into quad and increment by rs_c.
+" st1 {v9.s}[0],[x27],x14                    \n\t" // Store c34  into quad and increment by rs_c.
+" st1 {v9.s}[1],[x27],x14                    \n\t" // Store c35  into quad and increment by rs_c.
+" st1 {v9.s}[2],[x27],x14                    \n\t" // Store c36  into quad and increment by rs_c.
+" st1 {v9.s}[3],[x27],x14                    \n\t" // Store c37  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x19                               \n\t"
+"                                            \n\t"
+" st1 {v10.s}[0],[x27],x14                   \n\t" // Store c40  into quad and increment by rs_c.
+" st1 {v10.s}[1],[x27],x14                   \n\t" // Store c41  into quad and increment by rs_c.
+" st1 {v10.s}[2],[x27],x14                   \n\t" // Store c42  into quad and increment by rs_c.
+" st1 {v10.s}[3],[x27],x14                   \n\t" // Store c43  into quad and increment by rs_c.
+" st1 {v11.s}[0],[x27],x14                   \n\t" // Store c44  into quad and increment by rs_c.
+" st1 {v11.s}[1],[x27],x14                   \n\t" // Store c45  into quad and increment by rs_c.
+" st1 {v11.s}[2],[x27],x14                   \n\t" // Store c46  into quad and increment by rs_c.
+" st1 {v11.s}[3],[x27],x14                   \n\t" // Store c47  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x20                               \n\t"
+"                                            \n\t"
+" st1 {v12.s}[0],[x27],x14                   \n\t" // Store c50  into quad and increment by rs_c.
+" st1 {v12.s}[1],[x27],x14                   \n\t" // Store c51  into quad and increment by rs_c.
+" st1 {v12.s}[2],[x27],x14                   \n\t" // Store c52  into quad and increment by rs_c.
+" st1 {v12.s}[3],[x27],x14                   \n\t" // Store c53  into quad and increment by rs_c.
+" st1 {v13.s}[0],[x27],x14                   \n\t" // Store c54  into quad and increment by rs_c.
+" st1 {v13.s}[1],[x27],x14                   \n\t" // Store c55  into quad and increment by rs_c.
+" st1 {v13.s}[2],[x27],x14                   \n\t" // Store c56  into quad and increment by rs_c.
+" st1 {v13.s}[3],[x27],x14                   \n\t" // Store c57  into quad and increment by rs_c.
+"                                            \n\t"
+" dup  v0.4s, wzr                            \n\t"
+" dup  v1.4s, wzr                            \n\t"
+" dup  v2.4s, wzr                            \n\t"
+" dup  v3.4s, wzr                            \n\t"
+" dup  v4.4s, wzr                            \n\t"
+" dup  v5.4s, wzr                            \n\t"
+"                                            \n\t"
+" fcmp s7,#0.0                               \n\t"
+BEQ(SBETAZEROGENSTOREDS3) // Taking care of the beta==0 case.
+"                                            \n\t"
+" mov x27, x21                               \n\t"
+"                                            \n\t"
+" ld1 {v0.s}[0],[x27],x14                    \n\t" // Load c60  into quad and increment by rs_c.
+" ld1 {v0.s}[1],[x27],x14                    \n\t" // Load c61  into quad and increment by rs_c.
+" ld1 {v0.s}[2],[x27],x14                    \n\t" // Load c62  into quad and increment by rs_c.
+" ld1 {v0.s}[3],[x27],x14                    \n\t" // Load c63  into quad and increment by rs_c.
+" ld1 {v1.s}[0],[x27],x14                    \n\t" // Load c64  into quad and increment by rs_c.
+" ld1 {v1.s}[1],[x27],x14                    \n\t" // Load c65  into quad and increment by rs_c.
+" ld1 {v1.s}[2],[x27],x14                    \n\t" // Load c66  into quad and increment by rs_c.
+" ld1 {v1.s}[3],[x27],x14                    \n\t" // Load c67  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x22                               \n\t"
+"                                            \n\t"
+" ld1 {v2.s}[0],[x27],x14                    \n\t" // Load c70  into quad and increment by rs_c.
+" ld1 {v2.s}[1],[x27],x14                    \n\t" // Load c71  into quad and increment by rs_c.
+" ld1 {v2.s}[2],[x27],x14                    \n\t" // Load c72  into quad and increment by rs_c.
+" ld1 {v2.s}[3],[x27],x14                    \n\t" // Load c73  into quad and increment by rs_c.
+" ld1 {v3.s}[0],[x27],x14                    \n\t" // Load c74  into quad and increment by rs_c.
+" ld1 {v3.s}[1],[x27],x14                    \n\t" // Load c75  into quad and increment by rs_c.
+" ld1 {v3.s}[2],[x27],x14                    \n\t" // Load c76  into quad and increment by rs_c.
+" ld1 {v3.s}[3],[x27],x14                    \n\t" // Load c77  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x23                               \n\t"
+"                                            \n\t"
+" ld1 {v4.s}[0],[x27],x14                    \n\t" // Load c80  into quad and increment by rs_c.
+" ld1 {v4.s}[1],[x27],x14                    \n\t" // Load c81  into quad and increment by rs_c.
+" ld1 {v4.s}[2],[x27],x14                    \n\t" // Load c82  into quad and increment by rs_c.
+" ld1 {v4.s}[3],[x27],x14                    \n\t" // Load c83  into quad and increment by rs_c.
+" ld1 {v5.s}[0],[x27],x14                    \n\t" // Load c84  into quad and increment by rs_c.
+" ld1 {v5.s}[1],[x27],x14                    \n\t" // Load c85  into quad and increment by rs_c.
+" ld1 {v5.s}[2],[x27],x14                    \n\t" // Load c86  into quad and increment by rs_c.
+" ld1 {v5.s}[3],[x27],x14                    \n\t" // Load c87  into quad and increment by rs_c.
+"                                            \n\t"
+" fmul v0.4s,v0.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v1.4s,v1.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v2.4s,v2.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v3.4s,v3.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v4.4s,v4.4s,v7.s[0]                   \n\t" // Scale by beta
+" fmul v5.4s,v5.4s,v7.s[0]                   \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(SBETAZEROGENSTOREDS3)
+"                                            \n\t"
+" fmla v0.4s,v20.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v1.4s,v21.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v2.4s,v22.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v3.4s,v23.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v4.4s,v24.4s,v6.s[0]                  \n\t" // Scale by alpha
+" fmla v5.4s,v25.4s,v6.s[0]                  \n\t" // Scale by alpha
+"                                            \n\t"
+" mov x27, x21                               \n\t"
+"                                            \n\t"
+" st1 {v0.s}[0],[x27],x14                    \n\t" // Store c60  into quad and increment by rs_c.
+" st1 {v0.s}[1],[x27],x14                    \n\t" // Store c61  into quad and increment by rs_c.
+" st1 {v0.s}[2],[x27],x14                    \n\t" // Store c62  into quad and increment by rs_c.
+" st1 {v0.s}[3],[x27],x14                    \n\t" // Store c63  into quad and increment by rs_c.
+" st1 {v1.s}[0],[x27],x14                    \n\t" // Store c64  into quad and increment by rs_c.
+" st1 {v1.s}[1],[x27],x14                    \n\t" // Store c65  into quad and increment by rs_c.
+" st1 {v1.s}[2],[x27],x14                    \n\t" // Store c66  into quad and increment by rs_c.
+" st1 {v1.s}[3],[x27],x14                    \n\t" // Store c67  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x22                               \n\t"
+"                                            \n\t"
+" st1 {v2.s}[0],[x27],x14                    \n\t" // Store c70  into quad and increment by rs_c.
+" st1 {v2.s}[1],[x27],x14                    \n\t" // Store c71  into quad and increment by rs_c.
+" st1 {v2.s}[2],[x27],x14                    \n\t" // Store c72  into quad and increment by rs_c.
+" st1 {v2.s}[3],[x27],x14                    \n\t" // Store c73  into quad and increment by rs_c.
+" st1 {v3.s}[0],[x27],x14                    \n\t" // Store c74  into quad and increment by rs_c.
+" st1 {v3.s}[1],[x27],x14                    \n\t" // Store c75  into quad and increment by rs_c.
+" st1 {v3.s}[2],[x27],x14                    \n\t" // Store c76  into quad and increment by rs_c.
+" st1 {v3.s}[3],[x27],x14                    \n\t" // Store c77  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x23                               \n\t"
+"                                            \n\t"
+" st1 {v4.s}[0],[x27],x14                    \n\t" // Store c80  into quad and increment by rs_c.
+" st1 {v4.s}[1],[x27],x14                    \n\t" // Store c81  into quad and increment by rs_c.
+" st1 {v4.s}[2],[x27],x14                    \n\t" // Store c82  into quad and increment by rs_c.
+" st1 {v4.s}[3],[x27],x14                    \n\t" // Store c83  into quad and increment by rs_c.
+" st1 {v5.s}[0],[x27],x14                    \n\t" // Store c84  into quad and increment by rs_c.
+" st1 {v5.s}[1],[x27],x14                    \n\t" // Store c85  into quad and increment by rs_c.
+" st1 {v5.s}[2],[x27],x14                    \n\t" // Store c86  into quad and increment by rs_c.
+" st1 {v5.s}[3],[x27],x14                    \n\t" // Store c87  into quad and increment by rs_c.
+"                                            \n\t"
+" dup  v8.4s, wzr                            \n\t"
+" dup  v9.4s, wzr                            \n\t"
+" dup  v10.4s, wzr                           \n\t"
+" dup  v11.4s, wzr                           \n\t"
+" dup  v12.4s, wzr                           \n\t"
+" dup  v13.4s, wzr                           \n\t"
+"                                            \n\t"
+" fcmp s7,#0.0                               \n\t"
+BEQ(SBETAZEROGENSTOREDS4) // Taking care of the beta==0 case.
+"                                            \n\t"
+" mov x27, x24                               \n\t"
+"                                            \n\t"
+" ld1 {v8.s}[0],[x27],x14                    \n\t" // Load c90  into quad and increment by rs_c.
+" ld1 {v8.s}[1],[x27],x14                    \n\t" // Load c91  into quad and increment by rs_c.
+" ld1 {v8.s}[2],[x27],x14                    \n\t" // Load c92  into quad and increment by rs_c.
+" ld1 {v8.s}[3],[x27],x14                    \n\t" // Load c93  into quad and increment by rs_c.
+" ld1 {v9.s}[0],[x27],x14                    \n\t" // Load c94  into quad and increment by rs_c.
+" ld1 {v9.s}[1],[x27],x14                    \n\t" // Load c95  into quad and increment by rs_c.
+" ld1 {v9.s}[2],[x27],x14                    \n\t" // Load c96  into quad and increment by rs_c.
+" ld1 {v9.s}[3],[x27],x14                    \n\t" // Load c97  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x25                               \n\t"
+"                                            \n\t"
+" ld1 {v10.s}[0],[x27],x14                   \n\t" // Load c100  into quad and increment by rs_c.
+" ld1 {v10.s}[1],[x27],x14                   \n\t" // Load c101  into quad and increment by rs_c.
+" ld1 {v10.s}[2],[x27],x14                   \n\t" // Load c102  into quad and increment by rs_c.
+" ld1 {v10.s}[3],[x27],x14                   \n\t" // Load c103  into quad and increment by rs_c.
+" ld1 {v11.s}[0],[x27],x14                   \n\t" // Load c104  into quad and increment by rs_c.
+" ld1 {v11.s}[1],[x27],x14                   \n\t" // Load c105  into quad and increment by rs_c.
+" ld1 {v11.s}[2],[x27],x14                   \n\t" // Load c106  into quad and increment by rs_c.
+" ld1 {v11.s}[3],[x27],x14                   \n\t" // Load c107  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x26                               \n\t"
+"                                            \n\t"
+" ld1 {v12.s}[0],[x27],x14                   \n\t" // Load c110  into quad and increment by rs_c.
+" ld1 {v12.s}[1],[x27],x14                   \n\t" // Load c111  into quad and increment by rs_c.
+" ld1 {v12.s}[2],[x27],x14                   \n\t" // Load c112  into quad and increment by rs_c.
+" ld1 {v12.s}[3],[x27],x14                   \n\t" // Load c113  into quad and increment by rs_c.
+" ld1 {v13.s}[0],[x27],x14                   \n\t" // Load c114  into quad and increment by rs_c.
+" ld1 {v13.s}[1],[x27],x14                   \n\t" // Load c115  into quad and increment by rs_c.
+" ld1 {v13.s}[2],[x27],x14                   \n\t" // Load c116  into quad and increment by rs_c.
+" ld1 {v13.s}[3],[x27],x14                   \n\t" // Load c117  into quad and increment by rs_c.
+"                                            \n\t"
+" fmul v8.4s, v8.4s, v7.s[0]                 \n\t" // Scale by beta
+" fmul v9.4s, v9.4s, v7.s[0]                 \n\t" // Scale by beta
+" fmul v10.4s,v10.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v11.4s,v11.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v12.4s,v12.4s,v7.s[0]                 \n\t" // Scale by beta
+" fmul v13.4s,v13.4s,v7.s[0]                 \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(SBETAZEROGENSTOREDS4)
+"                                            \n\t"
+" prfm pldl2keep,[x3]                        \n\t"
+" prfm pldl2keep,[x4]                        \n\t"
+"                                            \n\t"
+" fmla v8.4s, v26.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v9.4s, v27.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v10.4s,v28.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v11.4s,v29.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v12.4s,v30.4s,v6.s[0]                 \n\t" // Scale by alpha
+" fmla v13.4s,v31.4s,v6.s[0]                 \n\t" // Scale by alpha
+"                                            \n\t"
+" mov x27, x24                               \n\t"
+"                                            \n\t"
+" st1 {v8.s}[0],[x27],x14                    \n\t" // Store c90  into quad and increment by rs_c.
+" st1 {v8.s}[1],[x27],x14                    \n\t" // Store c91  into quad and increment by rs_c.
+" st1 {v8.s}[2],[x27],x14                    \n\t" // Store c92  into quad and increment by rs_c.
+" st1 {v8.s}[3],[x27],x14                    \n\t" // Store c93  into quad and increment by rs_c.
+" st1 {v9.s}[0],[x27],x14                    \n\t" // Store c94  into quad and increment by rs_c.
+" st1 {v9.s}[1],[x27],x14                    \n\t" // Store c95  into quad and increment by rs_c.
+" st1 {v9.s}[2],[x27],x14                    \n\t" // Store c96  into quad and increment by rs_c.
+" st1 {v9.s}[3],[x27],x14                    \n\t" // Store c97  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x25                               \n\t"
+"                                            \n\t"
+" st1 {v10.s}[0],[x27],x14                   \n\t" // Store c100  into quad and increment by rs_c.
+" st1 {v10.s}[1],[x27],x14                   \n\t" // Store c101  into quad and increment by rs_c.
+" st1 {v10.s}[2],[x27],x14                   \n\t" // Store c102  into quad and increment by rs_c.
+" st1 {v10.s}[3],[x27],x14                   \n\t" // Store c103  into quad and increment by rs_c.
+" st1 {v11.s}[0],[x27],x14                   \n\t" // Store c104  into quad and increment by rs_c.
+" st1 {v11.s}[1],[x27],x14                   \n\t" // Store c105  into quad and increment by rs_c.
+" st1 {v11.s}[2],[x27],x14                   \n\t" // Store c106  into quad and increment by rs_c.
+" st1 {v11.s}[3],[x27],x14                   \n\t" // Store c107  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x26                               \n\t"
+"                                            \n\t"
+" st1 {v12.s}[0],[x27],x14                   \n\t" // Store c110  into quad and increment by rs_c.
+" st1 {v12.s}[1],[x27],x14                   \n\t" // Store c111  into quad and increment by rs_c.
+" st1 {v12.s}[2],[x27],x14                   \n\t" // Store c112  into quad and increment by rs_c.
+" st1 {v12.s}[3],[x27],x14                   \n\t" // Store c113  into quad and increment by rs_c.
+" st1 {v13.s}[0],[x27],x14                   \n\t" // Store c114  into quad and increment by rs_c.
+" st1 {v13.s}[1],[x27],x14                   \n\t" // Store c115  into quad and increment by rs_c.
+" st1 {v13.s}[2],[x27],x14                   \n\t" // Store c116  into quad and increment by rs_c.
+" st1 {v13.s}[3],[x27],x14                   \n\t" // Store c147  into quad and increment by rs_c.
+"                                            \n\t"
+LABEL(SEND) // Done!
+"                                            \n\t"
+:// output operands (none)
+:// input operands
+ [aaddr]  "m" (a),      // 0
+ [baddr]  "m" (b),      // 1
+ [caddr]  "m" (c),      // 2
+ [k_iter] "m" (k_iter), // 3
+ [k_left] "m" (k_left), // 4
+ [alpha]  "m" (alpha),  // 5
+ [beta]   "m" (beta),   // 6
+ [rs_c]   "m" (rs_c),   // 7
+ [cs_c]   "m" (cs_c),   // 8
+ [a_next] "m" (a_next), // 9
+ [b_next] "m" (b_next) // 10
+:// Register clobber list
+ "x0", "x1", "x2","x3","x4",
+ "x5", "x6", "x7", "x8",
+ "x9", "x10","x11","x12",
+ "x13","x14","x15",
+ "x16","x17","x18","x19",       
+ "x20","x21","x22","x23",
+ "x24","x25","x26","x27",
+ "v0", "v1", "v2", "v3",
+ "v4", "v5", "v6", "v7",
+ "v8", "v9", "v10","v11",
+ "v12","v13","v14","v15",
+ "v16","v17","v18","v19",
+ "v20","v21","v22","v23",
+ "v24","v25","v26","v27",
+ "v28","v29","v30","v31"
+);
+
+}
+
+
+/*
+   o 4x4 Double precision micro-kernel NOT fully functional yet.
+   o Runnable on ARMv8, compiled with aarch64 GCC.
+   o Use it together with the armv8 BLIS configuration.
+   o Tested on Juno board. Around 3 GFLOPS @ 1.1 GHz. 
+
+   December 2014.
+  
+ * UPDATE OCTOBER 2015: Now is fully functional.
+ * Tested on Juno board. Around 5.6 GFLOPS, 2 A57 cores @ 1.1 GHz.
+ * Tested on Juno board. Around 4 GFLOPS, 4 A53 cores @ 850 MHz.
+ 
+ * UPDATE NOVEMBER 2015
+ * Micro-kernel changed to 6x8
+ * Tested on Juno Board. Around 4   GFLOPS, 1 x A57 core  @ 1.1 GHz.
+ * Tested on Juno Board. Around 7.6 GFLOPS, 2 x A57 cores @ 1.1 GHz.
+ * Tested on Juno board. Around 1.5 GFLOPS, 1 x A53 core  @ 850 MHz. 
+ * Tested on Juno board. Around 5.5 GFLOPS, 4 x A53 cores @ 850 MHz.
+*/
+void bli_dgemm_armv8a_asm_6x8
+     (
+       dim_t               k0,
+       double*    restrict alpha,
+       double*    restrict a,
+       double*    restrict b,
+       double*    restrict beta,
+       double*    restrict c, inc_t rs_c0, inc_t cs_c0,
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
+     )
+{
+	void* a_next = bli_auxinfo_next_a( data );
+	void* b_next = bli_auxinfo_next_b( data );
+
+	// Typecast local copies of integers in case dim_t and inc_t are a
+	// different size than is expected by load instructions.
+	uint64_t k_iter = k0 / 4;
+	uint64_t k_left = k0 % 4;
+	uint64_t rs_c   = rs_c0;
+	uint64_t cs_c   = cs_c0;
+
+__asm__ volatile
+(
+"                                            \n\t" 
+" ldr x0,%[aaddr]                            \n\t" // Load address of A 
+" ldr x1,%[baddr]                            \n\t" // Load address of B
+" ldr x2,%[caddr]                            \n\t" // Load address of C
+"                                            \n\t"
+" ldr x3,%[a_next]                           \n\t" // Move pointer
+" ldr x4,%[b_next]                           \n\t" // Move pointer
+"                                            \n\t"
+" ldr x5,%[k_iter]                           \n\t" // Init guard (k_iter)
+" ldr x6,%[k_left]                           \n\t" // Init guard (k_iter)
+"                                            \n\t" 
+" ldr x7,%[alpha]                            \n\t" // Alpha address      
+" ldr x8,%[beta]                             \n\t" // Beta address      
+"                                            \n\t" 
+" ldr x9,%[cs_c]                             \n\t" // Load cs_c
+" lsl x10,x9,#3                              \n\t" // cs_c * sizeof(double)
+"                                            \n\t"
+" ldr x13,%[rs_c]                            \n\t" // Load rs_c.
+" lsl x14,x13,#3                             \n\t" // rs_c * sizeof(double). 
+"                                            \n\t"
+" add x20,x2,x10                             \n\t" //Load address Column 1 of C
+" add x21,x20,x10                            \n\t" //Load address Column 2 of C
+" add x22,x21,x10                            \n\t" //Load address Column 3 of C
+" add x23,x22,x10                            \n\t" //Load address Column 4 of C
+" add x24,x23,x10                            \n\t" //Load address Column 5 of C
+" add x25,x24,x10                            \n\t" //Load address Column 6 of C
+" add x26,x25,x10                            \n\t" //Load address Column 7 of C
+"                                            \n\t"
+" prfm pldl1keep,[x2]                        \n\t" // Prefetch c.
+" prfm pldl1keep,[x20]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x21]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x22]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x23]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x24]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x25]                       \n\t" // Prefetch c.
+" prfm pldl1keep,[x26]                       \n\t" // Prefetch c.
+"                                            \n\t"
+" dup  v8.2d, xzr                            \n\t" // Vector for accummulating column 0
+" prfm    PLDL1KEEP, [x1, #256]              \n\t" 
+" dup  v9.2d, xzr                            \n\t" // Vector for accummulating column 0
+" prfm    PLDL1KEEP, [x1, #320]              \n\t"
+" dup  v10.2d, xzr                           \n\t" // Vector for accummulating column 0
+" prfm    PLDL1KEEP, [x1, #384]              \n\t"
+" dup  v11.2d, xzr                           \n\t" // Vector for accummulating column 1
+" prfm    PLDL1KEEP, [x1, #448]              \n\t"
+" dup  v12.2d, xzr                           \n\t" // Vector for accummulating column 1 
+" dup  v13.2d, xzr                           \n\t" // Vector for accummulating column 1
+"                                            \n\t"
+" dup  v14.2d, xzr                           \n\t" // Vector for accummulating column 2
+" prfm    PLDL1KEEP, [x0, #192]              \n\t"
+" dup  v15.2d, xzr                           \n\t" // Vector for accummulating column 2
+" prfm    PLDL1KEEP, [x0, #256]              \n\t"
+" dup  v16.2d, xzr                           \n\t" // Vector for accummulating column 2
+" prfm    PLDL1KEEP, [x0, #320]              \n\t"
+" dup  v17.2d, xzr                           \n\t" // Vector for accummulating column 3
+" dup  v18.2d, xzr                           \n\t" // Vector for accummulating column 3 
+" dup  v19.2d, xzr                           \n\t" // Vector for accummulating column 3
+"                                            \n\t"
+" dup  v20.2d, xzr                           \n\t" // Vector for accummulating column 4 
+" dup  v21.2d, xzr                           \n\t" // Vector for accummulating column 4
+" dup  v22.2d, xzr                           \n\t" // Vector for accummulating column 4
+" dup  v23.2d, xzr                           \n\t" // Vector for accummulating column 5
+" dup  v24.2d, xzr                           \n\t" // Vector for accummulating column 5 
+" dup  v25.2d, xzr                           \n\t" // Vector for accummulating column 5
+"                                            \n\t"
+" dup  v26.2d, xzr                           \n\t" // Vector for accummulating column 6 
+" dup  v27.2d, xzr                           \n\t" // Vector for accummulating column 6
+" dup  v28.2d, xzr                           \n\t" // Vector for accummulating column 6
+" dup  v29.2d, xzr                           \n\t" // Vector for accummulating column 7
+" dup  v30.2d, xzr                           \n\t" // Vector for accummulating column 7 
+" dup  v31.2d, xzr                           \n\t" // Vector for accummulating column 7
+"                                            \n\t"
+"                                            \n\t"
+" cmp x5,#0                                  \n\t" // If k_iter == 0, jump to k_left.
+BEQ(DCONSIDERKLEFT)
+"                                            \n\t"
+" ldr q0, [x0]                               \n\t" // Load a
+" ldr q1, [x0, #16]                          \n\t"
+" ldr q2, [x0, #32]                          \n\t"
+"                                            \n\t"
+" ldr q3, [x1]                               \n\t" // Load b
+" ldr q4, [x1, #16]                          \n\t"
+" ldr q5, [x1, #32]                          \n\t"
+" ldr q6, [x1, #48]                          \n\t"
+"                                            \n\t"
+" add x0, x0, #48                            \n\t" //update address of A
+" add x1, x1, #64                            \n\t" //update address of B
+"                                            \n\t"
+" cmp x5,1                                   \n\t" // If there is just one k_iter, jump to that one. 
+BEQ(DLASTITER) // (as loop is do-while-like).
+"                                            \n\t"
+LABEL(DLOOP) // Body
+"                                            \n\t"
+" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
+" prfm    PLDL1KEEP, [x1, #448]              \n\t" //512-64=448
+" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
+" prfm    PLDL1KEEP, [x1, #512]              \n\t"
+" fmla v10.2d,v2.2d,v3.d[0]                  \n\t" // Accummulate
+" prfm    PLDL1KEEP, [x1, #576]              \n\t"
+"                                            \n\t"
+" fmla v11.2d,v0.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v12.2d,v1.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v13.2d,v2.2d,v3.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v14.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v16.2d,v2.2d,v4.d[0]                  \n\t" // Accummulate
+" ldr q3, [x1]                               \n\t"
+"                                            \n\t"
+" fmla v17.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v18.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v19.2d,v2.2d,v4.d[1]                  \n\t" // Accummulate
+" ldr q7, [x0, #32]                          \n\t"
+"                                            \n\t"
+" fmla v20.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v21.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v22.2d,v2.2d,v5.d[0]                  \n\t" // Accummulate
+" ldr q4, [x1, #16]                          \n\t"
+"                                            \n\t"
+" fmla v23.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v24.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v25.2d,v2.2d,v5.d[1]                  \n\t" // Accummulate
+" ldr q5, [x1, #32]                          \n\t"
+"                                            \n\t"
+" fmla v26.2d,v0.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v29.2d,v0.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q0, [x0]                               \n\t"
+"                                            \n\t"
+" fmla v27.2d,v1.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v30.2d,v1.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q1, [x0, #16]                          \n\t"
+"                                            \n\t"
+" fmla v28.2d,v2.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v31.2d,v2.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q6, [x1, #48]                          \n\t"
+"                                            \n\t"                  // End it 1
+" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
+" prfm    PLDL1KEEP, [x1, #640]              \n\t"
+" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
+" prfm    PLDL1KEEP, [x0, #336]              \n\t"
+" fmla v10.2d,v7.2d,v3.d[0]                  \n\t" // Accummulate
+" prfm    PLDL1KEEP, [x0, #400]              \n\t"
+"                                            \n\t"
+" fmla v11.2d,v0.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v12.2d,v1.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v13.2d,v7.2d,v3.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v14.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v16.2d,v7.2d,v4.d[0]                  \n\t" // Accummulate
+" ldr q3, [x1, #64]                          \n\t"
+"                                            \n\t"
+" fmla v17.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v18.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v19.2d,v7.2d,v4.d[1]                  \n\t" // Accummulate
+" ldr q2, [x0, #80]                          \n\t"
+"                                            \n\t"
+" fmla v20.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v21.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v22.2d,v7.2d,v5.d[0]                  \n\t" // Accummulate
+" ldr q4, [x1, #80]                          \n\t"
+"                                            \n\t"
+" fmla v23.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v24.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v25.2d,v7.2d,v5.d[1]                  \n\t" // Accummulate
+" ldr q5, [x1, #96]                          \n\t"
+"                                            \n\t"
+" fmla v26.2d,v0.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v29.2d,v0.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q0, [x0, #48]                          \n\t"
+"                                            \n\t"
+" fmla v27.2d,v1.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v30.2d,v1.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q1, [x0, #64]                          \n\t"
+"                                            \n\t"
+" fmla v28.2d,v7.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v31.2d,v7.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q6, [x1, #112]                         \n\t"
+"                                            \n\t"                  //End it 2
+" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
+" prfm    PLDL1KEEP, [x0, #464]              \n\t"
+" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v10.2d,v2.2d,v3.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v11.2d,v0.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v12.2d,v1.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v13.2d,v2.2d,v3.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v14.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v16.2d,v2.2d,v4.d[0]                  \n\t" // Accummulate
+" ldr q3, [x1, #128]                         \n\t"
+"                                            \n\t"
+" fmla v17.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v18.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v19.2d,v2.2d,v4.d[1]                  \n\t" // Accummulate
+" ldr q7, [x0, #128]                         \n\t"
+"                                            \n\t"
+" fmla v20.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v21.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v22.2d,v2.2d,v5.d[0]                  \n\t" // Accummulate
+" ldr q4, [x1, #144]                         \n\t"
+"                                            \n\t"
+" fmla v23.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v24.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v25.2d,v2.2d,v5.d[1]                  \n\t" // Accummulate
+" ldr q5, [x1, #160]                         \n\t"
+"                                            \n\t"
+" fmla v26.2d,v0.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v29.2d,v0.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q0, [x0, #96]                          \n\t"
+"                                            \n\t"
+" fmla v27.2d,v1.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v30.2d,v1.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q1, [x0, #112]                         \n\t"
+"                                            \n\t"
+" fmla v28.2d,v2.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v31.2d,v2.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q6, [x1, #176]                         \n\t"
+"                                            \n\t"                  // End it 3
+" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v10.2d,v7.2d,v3.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v11.2d,v0.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v12.2d,v1.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v13.2d,v7.2d,v3.d[1]                  \n\t" // Accummulate
+" ldr q3, [x1, #192]                         \n\t"
+"                                            \n\t"
+" fmla v14.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v16.2d,v7.2d,v4.d[0]                  \n\t" // Accummulate
+" ldr q2, [x0, #176]                         \n\t"
+"                                            \n\t"
+" fmla v17.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v18.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v19.2d,v7.2d,v4.d[1]                  \n\t" // Accummulate
+" ldr q4, [x1, #208]                         \n\t"
+"                                            \n\t"
+" fmla v20.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v21.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v22.2d,v7.2d,v5.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v23.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v24.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v25.2d,v7.2d,v5.d[1]                  \n\t" // Accummulate
+" ldr q5, [x1, #224]                         \n\t"
+"                                            \n\t"
+" fmla v26.2d,v0.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v29.2d,v0.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q0, [x0, #144]                         \n\t"
+"                                            \n\t"
+" fmla v27.2d,v1.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v30.2d,v1.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q1, [x0, #160]                         \n\t"
+"                                            \n\t"
+" fmla v28.2d,v7.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v31.2d,v7.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q6, [x1, #240]                         \n\t"
+"                                            \n\t"                  //End it 4
+" add x0, x0, #192                           \n\t"
+" add x1, x1, #256                           \n\t"
+"                                            \n\t"
+" sub x5,x5,1                                \n\t" // i-=1
+" cmp x5,1                                   \n\t" // Iterate again if we are not in k_iter == 1.
+BNE(DLOOP)
+"                                            \n\t"
+LABEL(DLASTITER)
+"                                            \n\t"
+" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v10.2d,v2.2d,v3.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v11.2d,v0.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v12.2d,v1.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v13.2d,v2.2d,v3.d[1]                  \n\t" // Accummulate
+" ldr q3, [x1]                               \n\t"
+"                                            \n\t"
+" fmla v14.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v16.2d,v2.2d,v4.d[0]                  \n\t" // Accummulate
+" ldr q7, [x0, #32]                          \n\t"
+"                                            \n\t"
+" fmla v17.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v18.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v19.2d,v2.2d,v4.d[1]                  \n\t" // Accummulate
+" ldr q4, [x1, #16]                          \n\t"
+"                                            \n\t"
+" fmla v20.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v21.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v22.2d,v2.2d,v5.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v23.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v24.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v25.2d,v2.2d,v5.d[1]                  \n\t" // Accummulate
+" ldr q5, [x1, #32]                          \n\t"
+"                                            \n\t"
+" fmla v26.2d,v0.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v29.2d,v0.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q0, [x0]                               \n\t"
+"                                            \n\t"
+" fmla v27.2d,v1.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v30.2d,v1.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q1, [x0, #16]                          \n\t"
+"                                            \n\t"
+" fmla v28.2d,v2.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v31.2d,v2.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q6, [x1, #48]                          \n\t"
+"                                            \n\t"                  // End it 1
+" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v10.2d,v7.2d,v3.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v11.2d,v0.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v12.2d,v1.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v13.2d,v7.2d,v3.d[1]                  \n\t" // Accummulate
+" ldr q3, [x1, #64]                          \n\t"
+"                                            \n\t"
+" fmla v14.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v16.2d,v7.2d,v4.d[0]                  \n\t" // Accummulate
+" ldr q2, [x0, #80]                          \n\t"
+"                                            \n\t"
+" fmla v17.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v18.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v19.2d,v7.2d,v4.d[1]                  \n\t" // Accummulate
+" ldr q4, [x1, #80]                          \n\t"
+"                                            \n\t"
+" fmla v20.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v21.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v22.2d,v7.2d,v5.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v23.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v24.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v25.2d,v7.2d,v5.d[1]                  \n\t" // Accummulate
+" ldr q5, [x1, #96]                          \n\t"
+"                                            \n\t"
+" fmla v26.2d,v0.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v29.2d,v0.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q0, [x0, #48]                          \n\t"
+"                                            \n\t"
+" fmla v27.2d,v1.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v30.2d,v1.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q1, [x0, #64]                          \n\t"
+"                                            \n\t"
+" fmla v28.2d,v7.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v31.2d,v7.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q6, [x1, #112]                         \n\t"
+"                                            \n\t"                  //End it 2
+" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v10.2d,v2.2d,v3.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v11.2d,v0.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v12.2d,v1.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v13.2d,v2.2d,v3.d[1]                  \n\t" // Accummulate
+" ldr q3, [x1, #128]                         \n\t"
+"                                            \n\t"
+" fmla v14.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v16.2d,v2.2d,v4.d[0]                  \n\t" // Accummulate
+" ldr q7, [x0, #128]                         \n\t"
+"                                            \n\t"
+" fmla v17.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v18.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v19.2d,v2.2d,v4.d[1]                  \n\t" // Accummulate
+" ldr q4, [x1, #144]                         \n\t"
+"                                            \n\t"
+" fmla v20.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v21.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v22.2d,v2.2d,v5.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v23.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v24.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v25.2d,v2.2d,v5.d[1]                  \n\t" // Accummulate
+" ldr q5, [x1, #160]                         \n\t"
+"                                            \n\t"
+" fmla v26.2d,v0.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v29.2d,v0.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q0, [x0, #96]                          \n\t"
+"                                            \n\t"
+" fmla v27.2d,v1.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v30.2d,v1.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q1, [x0, #112]                         \n\t"
+"                                            \n\t"
+" fmla v28.2d,v2.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v31.2d,v2.2d,v6.d[1]                  \n\t" // Accummulate
+" ldr q6, [x1, #176]                         \n\t"
+"                                            \n\t"                  // End it 3
+" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v10.2d,v7.2d,v3.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v11.2d,v0.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v12.2d,v1.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v13.2d,v7.2d,v3.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v14.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v16.2d,v7.2d,v4.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v17.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v18.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v19.2d,v7.2d,v4.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v20.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v21.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v22.2d,v7.2d,v5.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v23.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v24.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v25.2d,v7.2d,v5.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v26.2d,v0.2d,v6.d[0]                  \n\t" // Accummulate
+" add x1, x1, #192                           \n\t"
+" fmla v29.2d,v0.2d,v6.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v27.2d,v1.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v30.2d,v1.2d,v6.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v28.2d,v7.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v31.2d,v7.2d,v6.d[1]                  \n\t" // Accummulate
+"                                            \n\t"                  //End it 4
+" add x0, x0, #144                           \n\t"
+"                                            \n\t"
+LABEL(DCONSIDERKLEFT)
+" cmp x6,0                                   \n\t" // If k_left == 0, we are done.
+BEQ(DPOSTACCUM) // else, we enter the k_left loop.
+"                                            \n\t"
+LABEL(DLOOPKLEFT)
+"                                            \n\t"
+" ldr q0, [x0],#16                           \n\t"
+" ldr q1, [x0],#16                           \n\t" // Load a
+" ldr q2, [x0],#16                           \n\t"
+"                                            \n\t"
+" ldr q3, [x1],#16                           \n\t" // Load b
+" ldr q4, [x1],#16                           \n\t"
+" ldr q5, [x1],#16                           \n\t"
+" ldr q6, [x1],#16                           \n\t"
+"                                            \n\t"
+" sub x6,x6,1                                \n\t"
+"                                            \n\t"
+" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
+" fmla v10.2d,v2.2d,v3.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v11.2d,v0.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v12.2d,v1.2d,v3.d[1]                  \n\t" // Accummulate
+" fmla v13.2d,v2.2d,v3.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v14.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v16.2d,v2.2d,v4.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v17.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v18.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+" fmla v19.2d,v2.2d,v4.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v20.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v21.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v22.2d,v2.2d,v5.d[0]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v23.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v24.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+" fmla v25.2d,v2.2d,v5.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v26.2d,v0.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v29.2d,v0.2d,v6.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v27.2d,v1.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v30.2d,v1.2d,v6.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v28.2d,v2.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v31.2d,v2.2d,v6.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" cmp x6,0                                   \n\t" // Iterate again.
+BNE(DLOOPKLEFT) // if i!=0.
+"                                            \n\t"
+LABEL(DPOSTACCUM)
+"                                            \n\t"
+" ld1r {v6.2d},[x7]                          \n\t" // Load alpha.
+" ld1r {v7.2d},[x8]                          \n\t" // Load beta
+"                                            \n\t"
+" cmp x13,#1                                 \n\t" // If rs_c != 1 (column-major)
+BNE(DGENSTORED)
+"                                            \n\t"
+LABEL(DCOLSTORED) // C is column-major.
+"                                            \n\t"
+" dup  v0.2d, xzr                            \n\t"
+" dup  v1.2d, xzr                            \n\t"
+" dup  v2.2d, xzr                            \n\t"
+" dup  v3.2d, xzr                            \n\t"
+" dup  v4.2d, xzr                            \n\t"
+" dup  v5.2d, xzr                            \n\t"
+"                                            \n\t"
+" fcmp d7,#0.0                               \n\t"
+BEQ(DBETAZEROCOLSTOREDS1) // Taking care of the beta==0 case.
+"                                            \n\t"
+" ldr q0, [x2]                               \n\t" //Load column 0 of C
+" ldr q1, [x2, #16]                          \n\t"
+" ldr q2, [x2, #32]                          \n\t"
+"                                            \n\t"
+" ldr q3, [x20]                              \n\t" //Load column 1 of C
+" ldr q4, [x20, #16]                         \n\t"
+" ldr q5, [x20, #32]                         \n\t"
+"                                            \n\t"
+" fmul v0.2d,v0.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v1.2d,v1.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v2.2d,v2.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v3.2d,v3.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v4.2d,v4.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v5.2d,v5.2d,v7.d[0]                   \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(DBETAZEROCOLSTOREDS1)
+"                                            \n\t"
+" fmla v0.2d,v8.2d,v6.d[0]                   \n\t" // Scale by alpha
+" fmla v1.2d,v9.2d,v6.d[0]                   \n\t" // Scale by alpha
+" fmla v2.2d,v10.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v3.2d,v11.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v4.2d,v12.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v5.2d,v13.2d,v6.d[0]                  \n\t" // Scale by alpha
+"                                            \n\t"
+" str q0, [x2]                               \n\t" //Store column 0 of C
+" str q1, [x2, #16]                          \n\t"
+" str q2, [x2, #32]                          \n\t"
+"                                            \n\t"
+" str q3, [x20]                              \n\t" //Store column 1 of C
+" str q4, [x20, #16]                         \n\t"
+" str q5, [x20, #32]                         \n\t"
+"                                            \n\t"
+" dup  v8.2d, xzr                            \n\t"
+" dup  v9.2d, xzr                            \n\t"
+" dup  v10.2d, xzr                           \n\t"
+" dup  v11.2d, xzr                           \n\t"
+" dup  v12.2d, xzr                           \n\t"
+" dup  v13.2d, xzr                           \n\t"
+"                                            \n\t"
+" fcmp d7,#0.0                               \n\t"
+BEQ(DBETAZEROCOLSTOREDS2) // Taking care of the beta==0 case.
+"                                            \n\t"
+" ldr q8, [x21]                              \n\t" //Load column 2 of C
+" ldr q9, [x21, #16]                         \n\t"
+" ldr q10, [x21, #32]                        \n\t"
+"                                            \n\t"
+" ldr q11, [x22]                             \n\t" //Load column 3 of C
+" ldr q12, [x22, #16]                        \n\t"
+" ldr q13, [x22, #32]                        \n\t"
+"                                            \n\t"
+" fmul v8.2d, v8.2d, v7.d[0]                 \n\t" // Scale by beta
+" fmul v9.2d, v9.2d, v7.d[0]                 \n\t" // Scale by beta
+" fmul v10.2d,v10.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v11.2d,v11.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v12.2d,v12.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v13.2d,v13.2d,v7.d[0]                 \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(DBETAZEROCOLSTOREDS2)
+"                                            \n\t"
+" fmla v8.2d, v14.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v9.2d, v15.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v10.2d,v16.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v11.2d,v17.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v12.2d,v18.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v13.2d,v19.2d,v6.d[0]                 \n\t" // Scale by alpha
+"                                            \n\t"
+" str q8, [x21]                              \n\t" //Store column 2 of C
+" str q9, [x21, #16]                         \n\t"
+" str q10, [x21, #32]                        \n\t"
+"                                            \n\t"
+" str q11, [x22]                             \n\t" //Store column 3 of C
+" str q12, [x22, #16]                        \n\t"
+" str q13, [x22, #32]                        \n\t"
+"                                            \n\t"
+" dup  v0.2d, xzr                            \n\t"
+" dup  v1.2d, xzr                            \n\t"
+" dup  v2.2d, xzr                            \n\t"
+" dup  v3.2d, xzr                            \n\t"
+" dup  v4.2d, xzr                            \n\t"
+" dup  v5.2d, xzr                            \n\t"
+"                                            \n\t"
+" fcmp d7,#0.0                               \n\t"
+BEQ(DBETAZEROCOLSTOREDS3) // Taking care of the beta==0 case.
+"                                            \n\t"
+" ldr q0, [x23]                              \n\t" //Load column 4 of C
+" ldr q1, [x23, #16]                         \n\t"
+" ldr q2, [x23, #32]                         \n\t"
+"                                            \n\t"
+" ldr q3, [x24]                              \n\t" //Load column 5 of C
+" ldr q4, [x24, #16]                         \n\t"
+" ldr q5, [x24, #32]                         \n\t"
+"                                            \n\t"
+" fmul v0.2d,v0.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v1.2d,v1.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v2.2d,v2.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v3.2d,v3.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v4.2d,v4.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v5.2d,v5.2d,v7.d[0]                   \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(DBETAZEROCOLSTOREDS3)
+"                                            \n\t"
+" fmla v0.2d,v20.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v1.2d,v21.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v2.2d,v22.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v3.2d,v23.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v4.2d,v24.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v5.2d,v25.2d,v6.d[0]                  \n\t" // Scale by alpha
+"                                            \n\t"
+" str q0, [x23]                              \n\t" //Store column 4 of C
+" str q1, [x23, #16]                         \n\t"
+" str q2, [x23, #32]                         \n\t"
+"                                            \n\t"
+" str q3, [x24]                              \n\t" //Store column 5 of C
+" str q4, [x24, #16]                         \n\t"
+" str q5, [x24, #32]                         \n\t"
+"                                            \n\t"
+" dup  v8.2d, xzr                            \n\t"
+" dup  v9.2d, xzr                            \n\t"
+" dup  v10.2d, xzr                           \n\t"
+" dup  v11.2d, xzr                           \n\t"
+" dup  v12.2d, xzr                           \n\t"
+" dup  v13.2d, xzr                           \n\t"
+"                                            \n\t"
+" fcmp d7,#0.0                               \n\t"
+BEQ(DBETAZEROCOLSTOREDS4) // Taking care of the beta==0 case.
+"                                            \n\t"
+" ldr q8, [x25]                              \n\t" //Load column 6 of C
+" ldr q9, [x25, #16]                         \n\t"
+" ldr q10, [x25, #32]                        \n\t"
+"                                            \n\t"
+" ldr q11, [x26]                             \n\t" //Load column 7 of C
+" ldr q12, [x26, #16]                        \n\t"
+" ldr q13, [x26, #32]                        \n\t"
+"                                            \n\t"
+" fmul v8.2d, v8.2d, v7.d[0]                 \n\t" // Scale by beta
+" fmul v9.2d, v9.2d, v7.d[0]                 \n\t" // Scale by beta
+" fmul v10.2d,v10.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v11.2d,v11.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v12.2d,v12.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v13.2d,v13.2d,v7.d[0]                 \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(DBETAZEROCOLSTOREDS4)
+"                                            \n\t"
+" prfm pldl2keep,[x3]                        \n\t"
+" prfm pldl2keep,[x4]                        \n\t"
+"                                            \n\t"
+" fmla v8.2d, v26.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v9.2d, v27.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v10.2d,v28.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v11.2d,v29.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v12.2d,v30.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v13.2d,v31.2d,v6.d[0]                 \n\t" // Scale by alpha
+"                                            \n\t"
+" str q8, [x25]                              \n\t" //Store column 6 of C
+" str q9, [x25, #16]                         \n\t"
+" str q10, [x25, #32]                        \n\t"
+"                                            \n\t"
+" str q11, [x26]                             \n\t" //Store column 7 of C
+" str q12, [x26, #16]                        \n\t"
+" str q13, [x26, #32]                        \n\t"
+"                                            \n\t"
+BRANCH(DEND)
+"                                            \n\t"
+LABEL(DGENSTORED) // C is general-stride stored.
+"                                            \n\t"
+" dup  v0.2d, xzr                            \n\t"
+" dup  v1.2d, xzr                            \n\t"
+" dup  v2.2d, xzr                            \n\t"
+" dup  v3.2d, xzr                            \n\t"
+" dup  v4.2d, xzr                            \n\t"
+" dup  v5.2d, xzr                            \n\t"
+"                                            \n\t"
+" fcmp d7,#0.0                               \n\t"
+BEQ(DBETAZEROGENSTOREDS1) // Taking care of the beta==0 case.
+"                                            \n\t"
+" mov x27, x2                                \n\t"
+"                                            \n\t" // Load address of C.
+" ld1 {v0.d}[0],[x27],x14                    \n\t" // Load c00  into quad and increment by rs_c.
+" ld1 {v0.d}[1],[x27],x14                    \n\t" // Load c01  into quad and increment by rs_c.
+" ld1 {v1.d}[0],[x27],x14                    \n\t" // Load c02  into quad and increment by rs_c.
+" ld1 {v1.d}[1],[x27],x14                    \n\t" // Load c03  into quad and increment by rs_c.
+" ld1 {v2.d}[0],[x27],x14                    \n\t" // Load c04  into quad and increment by rs_c.
+" ld1 {v2.d}[1],[x27],x14                    \n\t" // Load c05  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x20                               \n\t" // Load address of C.
+"                                            \n\t"
+" ld1 {v3.d}[0],[x27],x14                    \n\t" // Load c10  into quad and increment by rs_c.
+" ld1 {v3.d}[1],[x27],x14                    \n\t" // Load c11  into quad and increment by rs_c.
+" ld1 {v4.d}[0],[x27],x14                    \n\t" // Load c12  into quad and increment by rs_c.
+" ld1 {v4.d}[1],[x27],x14                    \n\t" // Load c13  into quad and increment by rs_c.
+" ld1 {v5.d}[0],[x27],x14                    \n\t" // Load c14  into quad and increment by rs_c.
+" ld1 {v5.d}[1],[x27],x14                    \n\t" // Load c15  into quad and increment by rs_c.
+"                                            \n\t"
+" fmul v0.2d,v0.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v1.2d,v1.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v2.2d,v2.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v3.2d,v3.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v4.2d,v4.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v5.2d,v5.2d,v7.d[0]                   \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(DBETAZEROGENSTOREDS1)
+"                                            \n\t"
+" fmla v0.2d,v8.2d,v6.d[0]                   \n\t" // Scale by alpha
+" fmla v1.2d,v9.2d,v6.d[0]                   \n\t" // Scale by alpha
+" fmla v2.2d,v10.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v3.2d,v11.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v4.2d,v12.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v5.2d,v13.2d,v6.d[0]                  \n\t" // Scale by alpha
+"                                            \n\t"
+" mov x27, x2                                \n\t" // Load address of C.
+"                                            \n\t"
+" st1 {v0.d}[0],[x27],x14                    \n\t" // Store c00  into quad and increment by rs_c.
+" st1 {v0.d}[1],[x27],x14                    \n\t" // Store c01  into quad and increment by rs_c.
+" st1 {v1.d}[0],[x27],x14                    \n\t" // Store c02  into quad and increment by rs_c.
+" st1 {v1.d}[1],[x27],x14                    \n\t" // Store c03  into quad and increment by rs_c.
+" st1 {v2.d}[0],[x27],x14                    \n\t" // Store c04  into quad and increment by rs_c.
+" st1 {v2.d}[1],[x27],x14                    \n\t" // Store c05  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x20                               \n\t" // Load address of C.
+"                                            \n\t"
+" st1 {v3.d}[0],[x27],x14                    \n\t" // Store c10  into quad and increment by rs_c.
+" st1 {v3.d}[1],[x27],x14                    \n\t" // Store c11  into quad and increment by rs_c.
+" st1 {v4.d}[0],[x27],x14                    \n\t" // Store c12  into quad and increment by rs_c.
+" st1 {v4.d}[1],[x27],x14                    \n\t" // Store c13  into quad and increment by rs_c.
+" st1 {v5.d}[0],[x27],x14                    \n\t" // Store c14  into quad and increment by rs_c.
+" st1 {v5.d}[1],[x27],x14                    \n\t" // Store c15  into quad and increment by rs_c.
+"                                            \n\t"
+" dup  v8.2d, xzr                            \n\t"
+" dup  v9.2d, xzr                            \n\t"
+" dup  v10.2d, xzr                           \n\t"
+" dup  v11.2d, xzr                           \n\t"
+" dup  v12.2d, xzr                           \n\t"
+" dup  v13.2d, xzr                           \n\t"
+"                                            \n\t"
+" fcmp d7,#0.0                               \n\t"
+BEQ(DBETAZEROGENSTOREDS2) // Taking care of the beta==0 case.
+"                                            \n\t"
+" mov x27, x21                               \n\t" // Load address of C.
+"                                            \n\t"
+" ld1 {v8.d}[0], [x27],x14                   \n\t" // Load c20  into quad and increment by rs_c.
+" ld1 {v8.d}[1], [x27],x14                   \n\t" // Load c21  into quad and increment by rs_c.
+" ld1 {v9.d}[0], [x27],x14                   \n\t" // Load c22  into quad and increment by rs_c.
+" ld1 {v9.d}[1], [x27],x14                   \n\t" // Load c23  into quad and increment by rs_c.
+" ld1 {v10.d}[0],[x27],x14                   \n\t" // Load c24  into quad and increment by rs_c.
+" ld1 {v10.d}[1],[x27],x14                   \n\t" // Load c25  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x22                               \n\t" // Load address of C.
+"                                            \n\t"
+" ld1 {v11.d}[0],[x27],x14                   \n\t" // Load c30  into quad and increment by rs_c.
+" ld1 {v11.d}[1],[x27],x14                   \n\t" // Load c31  into quad and increment by rs_c.
+" ld1 {v12.d}[0],[x27],x14                   \n\t" // Load c32  into quad and increment by rs_c.
+" ld1 {v12.d}[1],[x27],x14                   \n\t" // Load c33  into quad and increment by rs_c.
+" ld1 {v13.d}[0],[x27],x14                   \n\t" // Load c34  into quad and increment by rs_c.
+" ld1 {v13.d}[1],[x27],x14                   \n\t" // Load c35  into quad and increment by rs_c.
+"                                            \n\t"
+" fmul v8.2d, v8.2d, v7.d[0]                 \n\t" // Scale by beta
+" fmul v9.2d, v9.2d, v7.d[0]                 \n\t" // Scale by beta
+" fmul v10.2d,v10.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v11.2d,v11.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v12.2d,v12.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v13.2d,v13.2d,v7.d[0]                 \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(DBETAZEROGENSTOREDS2)
+"                                            \n\t"
+" fmla v8.2d, v14.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v9.2d, v15.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v10.2d,v16.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v11.2d,v17.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v12.2d,v18.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v13.2d,v19.2d,v6.d[0]                 \n\t" // Scale by alpha
+"                                            \n\t"
+" mov x27, x21                               \n\t" // Load address of C.
+"                                            \n\t"
+" st1 {v8.d}[0], [x27],x14                   \n\t" // Store c20  into quad and increment by rs_c.
+" st1 {v8.d}[1], [x27],x14                   \n\t" // Store c21  into quad and increment by rs_c.
+" st1 {v9.d}[0], [x27],x14                   \n\t" // Store c22  into quad and increment by rs_c.
+" st1 {v9.d}[1], [x27],x14                   \n\t" // Store c23  into quad and increment by rs_c.
+" st1 {v10.d}[0],[x27],x14                   \n\t" // Store c24  into quad and increment by rs_c.
+" st1 {v10.d}[1],[x27],x14                   \n\t" // Store c25  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x22                               \n\t" // Load address of C.
+"                                            \n\t"
+" st1 {v11.d}[0],[x27],x14                   \n\t" // Store c30  into quad and increment by rs_c.
+" st1 {v11.d}[1],[x27],x14                   \n\t" // Store c31  into quad and increment by rs_c.
+" st1 {v12.d}[0],[x27],x14                   \n\t" // Store c32  into quad and increment by rs_c.
+" st1 {v12.d}[1],[x27],x14                   \n\t" // Store c33  into quad and increment by rs_c.
+" st1 {v13.d}[0],[x27],x14                   \n\t" // Store c34  into quad and increment by rs_c.
+" st1 {v13.d}[1],[x27],x14                   \n\t" // Store c35  into quad and increment by rs_c.
+"                                            \n\t"
+" dup  v0.2d, xzr                            \n\t"
+" dup  v1.2d, xzr                            \n\t"
+" dup  v2.2d, xzr                            \n\t"
+" dup  v3.2d, xzr                            \n\t"
+" dup  v4.2d, xzr                            \n\t"
+" dup  v5.2d, xzr                            \n\t"
+"                                            \n\t"
+" fcmp d7,#0.0                               \n\t"
+BEQ(DBETAZEROGENSTOREDS3) // Taking care of the beta==0 case.
+"                                            \n\t"
+" mov x27, x23                               \n\t" // Load address of C.
+"                                            \n\t"
+" ld1 {v0.d}[0],[x27],x14                    \n\t" // Load c40  into quad and increment by rs_c.
+" ld1 {v0.d}[1],[x27],x14                    \n\t" // Load c41  into quad and increment by rs_c.
+" ld1 {v1.d}[0],[x27],x14                    \n\t" // Load c42  into quad and increment by rs_c.
+" ld1 {v1.d}[1],[x27],x14                    \n\t" // Load c43  into quad and increment by rs_c.
+" ld1 {v2.d}[0],[x27],x14                    \n\t" // Load c44  into quad and increment by rs_c.
+" ld1 {v2.d}[1],[x27],x14                    \n\t" // Load c45  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x24                               \n\t" // Load address of C.
+"                                            \n\t"
+" ld1 {v3.d}[0],[x27],x14                    \n\t" // Load c50  into quad and increment by rs_c.
+" ld1 {v3.d}[1],[x27],x14                    \n\t" // Load c51  into quad and increment by rs_c.
+" ld1 {v4.d}[0],[x27],x14                    \n\t" // Load c52  into quad and increment by rs_c.
+" ld1 {v4.d}[1],[x27],x14                    \n\t" // Load c53  into quad and increment by rs_c.
+" ld1 {v5.d}[0],[x27],x14                    \n\t" // Load c54  into quad and increment by rs_c.
+" ld1 {v5.d}[1],[x27],x14                    \n\t" // Load c55  into quad and increment by rs_c.
+"                                            \n\t"
+" fmul v0.2d,v0.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v1.2d,v1.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v2.2d,v2.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v3.2d,v3.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v4.2d,v4.2d,v7.d[0]                   \n\t" // Scale by beta
+" fmul v5.2d,v5.2d,v7.d[0]                   \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(DBETAZEROGENSTOREDS3)
+"                                            \n\t"
+" fmla v0.2d,v20.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v1.2d,v21.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v2.2d,v22.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v3.2d,v23.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v4.2d,v24.2d,v6.d[0]                  \n\t" // Scale by alpha
+" fmla v5.2d,v25.2d,v6.d[0]                  \n\t" // Scale by alpha
+"                                            \n\t"
+" mov x27, x23                               \n\t" // Load address of C.
+"                                            \n\t"
+" st1 {v0.d}[0],[x27],x14                    \n\t" // Store c40  into quad and increment by rs_c.
+" st1 {v0.d}[1],[x27],x14                    \n\t" // Store c41  into quad and increment by rs_c.
+" st1 {v1.d}[0],[x27],x14                    \n\t" // Store c42  into quad and increment by rs_c.
+" st1 {v1.d}[1],[x27],x14                    \n\t" // Store c43  into quad and increment by rs_c.
+" st1 {v2.d}[0],[x27],x14                    \n\t" // Store c44  into quad and increment by rs_c.
+" st1 {v2.d}[1],[x27],x14                    \n\t" // Store c45  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x24                               \n\t" // Load address of C.
+"                                            \n\t"
+" st1 {v3.d}[0],[x27],x14                    \n\t" // Store c50  into quad and increment by rs_c.
+" st1 {v3.d}[1],[x27],x14                    \n\t" // Store c51  into quad and increment by rs_c.
+" st1 {v4.d}[0],[x27],x14                    \n\t" // Store c52  into quad and increment by rs_c.
+" st1 {v4.d}[1],[x27],x14                    \n\t" // Store c53  into quad and increment by rs_c.
+" st1 {v5.d}[0],[x27],x14                    \n\t" // Store c54  into quad and increment by rs_c.
+" st1 {v5.d}[1],[x27],x14                    \n\t" // Store c55  into quad and increment by rs_c.
+"                                            \n\t"
+" dup  v8.2d, xzr                            \n\t"
+" dup  v9.2d, xzr                            \n\t"
+" dup  v10.2d, xzr                           \n\t"
+" dup  v11.2d, xzr                           \n\t"
+" dup  v12.2d, xzr                           \n\t"
+" dup  v13.2d, xzr                           \n\t"
+"                                            \n\t"
+" fcmp d7,#0.0                               \n\t"
+BEQ(DBETAZEROGENSTOREDS4) // Taking care of the beta==0 case.
+"                                            \n\t"
+" mov x27, x25                               \n\t"
+"                                            \n\t"
+" ld1 {v8.d}[0], [x27],x14                   \n\t" // Load c60  into quad and increment by rs_c.
+" ld1 {v8.d}[1], [x27],x14                   \n\t" // Load c61  into quad and increment by rs_c.
+" ld1 {v9.d}[0], [x27],x14                   \n\t" // Load c62  into quad and increment by rs_c.
+" ld1 {v9.d}[1], [x27],x14                   \n\t" // Load c63  into quad and increment by rs_c.
+" ld1 {v10.d}[0],[x27],x14                   \n\t" // Load c64  into quad and increment by rs_c.
+" ld1 {v10.d}[1],[x27],x14                   \n\t" // Load c65  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x26                               \n\t" // Load address of C.
+"                                            \n\t"
+" ld1 {v11.d}[0],[x27],x14                   \n\t" // Load c70  into quad and increment by rs_c.
+" ld1 {v11.d}[1],[x27],x14                   \n\t" // Load c71  into quad and increment by rs_c.
+" ld1 {v12.d}[0],[x27],x14                   \n\t" // Load c72  into quad and increment by rs_c.
+" ld1 {v12.d}[1],[x27],x14                   \n\t" // Load c73  into quad and increment by rs_c.
+" ld1 {v13.d}[0],[x27],x14                   \n\t" // Load c74  into quad and increment by rs_c.
+" ld1 {v13.d}[1],[x27],x14                   \n\t" // Load c75  into quad and increment by rs_c.
+"                                            \n\t"
+" fmul v8.2d, v8.2d, v7.d[0]                 \n\t" // Scale by beta
+" fmul v9.2d, v9.2d, v7.d[0]                 \n\t" // Scale by beta
+" fmul v10.2d,v10.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v11.2d,v11.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v12.2d,v12.2d,v7.d[0]                 \n\t" // Scale by beta
+" fmul v13.2d,v13.2d,v7.d[0]                 \n\t" // Scale by beta
+"                                            \n\t"
+LABEL(DBETAZEROGENSTOREDS4)
+"                                            \n\t"
+" prfm pldl2keep,[x3]                        \n\t"
+" prfm pldl2keep,[x4]                        \n\t"
+"                                            \n\t"
+" fmla v8.2d, v26.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v9.2d, v27.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v10.2d,v28.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v11.2d,v29.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v12.2d,v30.2d,v6.d[0]                 \n\t" // Scale by alpha
+" fmla v13.2d,v31.2d,v6.d[0]                 \n\t" // Scale by alpha
+"                                            \n\t"
+" mov x27, x25                               \n\t" // Load address of C.
+"                                            \n\t"
+" st1 {v8.d}[0], [x27],x14                   \n\t" // Store c60  into quad and increment by rs_c.
+" st1 {v8.d}[1], [x27],x14                   \n\t" // Store c61  into quad and increment by rs_c.
+" st1 {v9.d}[0], [x27],x14                   \n\t" // Store c62  into quad and increment by rs_c.
+" st1 {v9.d}[1], [x27],x14                   \n\t" // Store c63  into quad and increment by rs_c.
+" st1 {v10.d}[0],[x27],x14                   \n\t" // Store c64  into quad and increment by rs_c.
+" st1 {v10.d}[1],[x27],x14                   \n\t" // Store c65  into quad and increment by rs_c.
+"                                            \n\t"
+" mov x27, x26                               \n\t" // Load address of C.
+"                                            \n\t"
+" st1 {v11.d}[0],[x27],x14                   \n\t" // Store c70  into quad and increment by rs_c.
+" st1 {v11.d}[1],[x27],x14                   \n\t" // Store c71  into quad and increment by rs_c.
+" st1 {v12.d}[0],[x27],x14                   \n\t" // Store c72  into quad and increment by rs_c.
+" st1 {v12.d}[1],[x27],x14                   \n\t" // Store c73  into quad and increment by rs_c.
+" st1 {v13.d}[0],[x27],x14                   \n\t" // Store c74  into quad and increment by rs_c.
+" st1 {v13.d}[1],[x27],x14                   \n\t" // Store c75  into quad and increment by rs_c.
+"                                            \n\t"
+LABEL(DEND) // Done!
+"                                            \n\t"
+:// output operands (none)
+:// input operands
+ [aaddr]  "m" (a),      // 0
+ [baddr]  "m" (b),      // 1
+ [caddr]  "m" (c),      // 2
+ [k_iter] "m" (k_iter), // 3
+ [k_left] "m" (k_left), // 4
+ [alpha]  "m" (alpha),  // 5
+ [beta]   "m" (beta),   // 6
+ [rs_c]   "m" (rs_c),   // 6
+ [cs_c]   "m" (cs_c),   // 7
+ [a_next] "m" (a_next), // 8
+ [b_next] "m" (b_next)  // 9
+:// Register clobber list
+ "x0","x1","x2","x3",
+ "x4","x5","x6",
+ "x7","x8","x9",
+ "x10","x11","x12","x13","x14","x16","x17",
+ "x20","x21","x22","x23","x24","x25","x26",
+ "x27",       
+ "v0","v1","v2",
+ "v3","v4","v5",
+ "v6","v7","v8",
+ "v9","v10","v11",
+ "v12","v13","v14",
+ "v15","v16","v17","v18","v19",
+ "v20","v21","v22","v23",
+ "v24","v25","v26","v27",
+ "v28","v29","v30","v31"
+);
+
+
+
+}
+
+
+#if 0
+void bli_cgemm_armv8a_opt_4x4
+     (
+       dim_t               k,
+       scomplex*  restrict alpha,
+       scomplex*  restrict a,
+       scomplex*  restrict b,
+       scomplex*  restrict beta,
+       scomplex*  restrict c, inc_t rs_c, inc_t cs_c,
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
+     )
+{
+}
+
+void bli_zgemm_armv8a_opt_4x4
+     (
+       dim_t               k,
+       dcomplex*  restrict alpha,
+       dcomplex*  restrict a,
+       dcomplex*  restrict b,
+       dcomplex*  restrict beta,
+       dcomplex*  restrict c, inc_t rs_c, inc_t cs_c,
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
+     )
+{
+}
+
+#endif
+

--- a/src/configs/armv8a/config.cxx
+++ b/src/configs/armv8a/config.cxx
@@ -1,0 +1,29 @@
+#include "config.hpp"
+
+#include "util/cpuid.hpp"
+
+namespace tblis
+{
+
+int armv8a_check()
+{
+    int family, model, features;
+    int vendor = get_cpu_type(family, model, features);
+
+    if (vendor != VENDOR_ARM)
+    {
+        if (get_verbose() >= 1) printf("tblis: armv8a: Wrong vendor.\n");
+        return -1;
+    }
+
+    // All Cortex-A supports NEON.
+    // if (!check_features(features, FEATURE_NEON))
+    // {
+    //     if (get_verbose() >= 1) printf("tblis: armv8a: Doesn't support NEON.\n");
+    //     return -1;
+    // }
+
+    return 1;
+}
+
+}

--- a/src/configs/armv8a/config.cxx
+++ b/src/configs/armv8a/config.cxx
@@ -7,12 +7,12 @@ namespace tblis
 
 int armv8a_check()
 {
-    int family, model, features;
-    int vendor = get_cpu_type(family, model, features);
+    int model, part, features;
+    int vendor = get_cpu_type(model, part, features);
 
-    if (vendor != VENDOR_ARM)
+    if (model != MODEL_ARMV8)
     {
-        if (get_verbose() >= 1) printf("tblis: armv8a: Wrong vendor.\n");
+        if (get_verbose() >= 1) printf("tblis: armv8a: Not Arm64.\n");
         return -1;
     }
 
@@ -23,7 +23,7 @@ int armv8a_check()
     //     return -1;
     // }
 
-    return 1;
+    return 2;
 }
 
 }

--- a/src/configs/armv8a/config.hpp
+++ b/src/configs/armv8a/config.hpp
@@ -1,0 +1,42 @@
+#ifndef _TBLIS_CONFIGS_ARM64_CONFIG_HPP_
+#define _TBLIS_CONFIGS_ARM64_CONFIG_HPP_
+
+#include "configs/config_builder.hpp"
+
+EXTERN_BLIS_GEMM_UKR(bli_sgemm_armv8a_asm_8x12);
+EXTERN_BLIS_GEMM_UKR(bli_dgemm_armv8a_asm_6x8);
+
+namespace tblis
+{
+
+extern int armv8a_check();
+
+TBLIS_BEGIN_CONFIG(armv8a)
+
+    TBLIS_CONFIG_GEMM_MR(   8,    6, _, _)
+    TBLIS_CONFIG_GEMM_NR(  12,    8, _, _)
+    TBLIS_CONFIG_GEMM_KR(   4,    4, _, _)
+    TBLIS_CONFIG_GEMM_MC( 120,  120, _, _)
+    TBLIS_CONFIG_GEMM_NC( 640,  240, _, _)
+    TBLIS_CONFIG_GEMM_KC(3072, 3072, _, _)
+                        
+    // TBLIS_CONFIG_M_THREAD_RATIO(_,3,_,_)
+    // TBLIS_CONFIG_N_THREAD_RATIO(_,2,_,_)
+    // TBLIS_CONFIG_MR_MAX_THREAD(_,1,_,_)
+    // TBLIS_CONFIG_NR_MAX_THREAD(_,4,_,_)
+
+    TBLIS_CONFIG_GEMM_WRAP_UKR(bli_sgemm_armv8a_asm_8x12,
+                               bli_dgemm_armv8a_asm_6x8,
+                               _,
+                               _)
+
+    TBLIS_CONFIG_GEMM_ROW_MAJOR(false, false, _, _)
+    TBLIS_CONFIG_GEMM_FLIP_UKR(true, true, _, _)
+
+    TBLIS_CONFIG_CHECK(armv8a_check)
+
+TBLIS_END_CONFIG
+
+}
+
+#endif

--- a/src/configs/armv8a/config.hpp
+++ b/src/configs/armv8a/config.hpp
@@ -1,5 +1,5 @@
-#ifndef _TBLIS_CONFIGS_ARM64_CONFIG_HPP_
-#define _TBLIS_CONFIGS_ARM64_CONFIG_HPP_
+#ifndef _TBLIS_CONFIGS_ARMV8A_CONFIG_HPP_
+#define _TBLIS_CONFIGS_ARMV8A_CONFIG_HPP_
 
 #include "configs/config_builder.hpp"
 

--- a/src/configs/armv8a/config_ker.cxx
+++ b/src/configs/armv8a/config_ker.cxx
@@ -1,0 +1,10 @@
+#include "config.hpp"
+
+#include "util/cpuid.hpp"
+
+namespace tblis
+{
+
+TBLIS_CONFIG_INSTANTIATE(armv8a);
+
+}

--- a/src/configs/thunderx2/config.cxx
+++ b/src/configs/thunderx2/config.cxx
@@ -1,0 +1,35 @@
+#include "config.hpp"
+
+#include "util/cpuid.hpp"
+
+namespace tblis
+{
+
+int thunderx2_check()
+{
+    int model, part, features;
+    int vendor = get_cpu_type(model, part, features);
+
+    if (model != MODEL_ARMV8)
+    {
+        if (get_verbose() >= 1) printf("tblis: thunderx2: Not Arm64.\n");
+        return -1;
+    }
+
+    // All Cortex-A supports NEON.
+    // if (!check_features(features, FEATURE_NEON))
+    // {
+    //     if (get_verbose() >= 1) printf("tblis: thunderx2: Doesn't support NEON.\n");
+    //     return -1;
+    // }
+
+    if (vendor != VENDOR_CAVIUM)
+    {
+        if (get_verbose() >= 1) printf("tblis: thunderx2: Wrong vendor.\n");
+        return -1;
+    }
+
+    return 3;
+}
+
+}

--- a/src/configs/thunderx2/config.hpp
+++ b/src/configs/thunderx2/config.hpp
@@ -1,0 +1,42 @@
+#ifndef _TBLIS_CONFIGS_THUNDERX2_CONFIG_HPP_
+#define _TBLIS_CONFIGS_THUNDERX2_CONFIG_HPP_
+
+#include "configs/config_builder.hpp"
+
+EXTERN_BLIS_GEMM_UKR(bli_sgemm_armv8a_asm_8x12);
+EXTERN_BLIS_GEMM_UKR(bli_dgemm_armv8a_asm_6x8);
+
+namespace tblis
+{
+
+extern int thunderx2_check();
+
+TBLIS_BEGIN_CONFIG(thunderx2)
+
+    TBLIS_CONFIG_GEMM_MR(   8,    6, _, _)
+    TBLIS_CONFIG_GEMM_NR(  12,    8, _, _)
+    TBLIS_CONFIG_GEMM_KR(   4,    4, _, _)
+    TBLIS_CONFIG_GEMM_MC( 120,  120, _, _)
+    TBLIS_CONFIG_GEMM_NC( 640,  240, _, _)
+    TBLIS_CONFIG_GEMM_KC(3072, 3072, _, _)
+                        
+    // TBLIS_CONFIG_M_THREAD_RATIO(_,3,_,_)
+    // TBLIS_CONFIG_N_THREAD_RATIO(_,2,_,_)
+    // TBLIS_CONFIG_MR_MAX_THREAD(_,1,_,_)
+    // TBLIS_CONFIG_NR_MAX_THREAD(_,4,_,_)
+
+    TBLIS_CONFIG_GEMM_WRAP_UKR(bli_sgemm_armv8a_asm_8x12,
+                               bli_dgemm_armv8a_asm_6x8,
+                               _,
+                               _)
+
+    TBLIS_CONFIG_GEMM_ROW_MAJOR(false, false, _, _)
+    TBLIS_CONFIG_GEMM_FLIP_UKR(true, true, _, _)
+
+    TBLIS_CONFIG_CHECK(thunderx2_check)
+
+TBLIS_END_CONFIG
+
+}
+
+#endif

--- a/src/configs/thunderx2/config_ker.cxx
+++ b/src/configs/thunderx2/config_ker.cxx
@@ -1,0 +1,10 @@
+#include "config.hpp"
+
+#include "util/cpuid.hpp"
+
+namespace tblis
+{
+
+TBLIS_CONFIG_INSTANTIATE(thunderx2);
+
+}

--- a/src/external/catch/catch.hpp
+++ b/src/external/catch/catch.hpp
@@ -2107,6 +2107,8 @@ namespace Catch{
         #define CATCH_TRAP() \
                 __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
                 : : : "memory","r0","r3","r4" )
+    #elif defined(__aarch64__) || defined(__arm__)
+        #define CATCH_TRAP() __asm__("brk #1\n" : : )
     #else
         #define CATCH_TRAP() __asm__("int $3\n" : : )
     #endif

--- a/src/external/marray/include/expression.hpp
+++ b/src/external/marray/include/expression.hpp
@@ -1,7 +1,9 @@
 #ifndef _MARRAY_EXPRESSION_HPP_
 #define _MARRAY_EXPRESSION_HPP_
 
+#if (defined(__i386) || defined(__x86_64))
 #include <x86intrin.h>
+#endif
 
 #include "utility.hpp"
 #include "vector.hpp"

--- a/src/external/tci/tci/task_set.c
+++ b/src/external/tci/tci/task_set.c
@@ -1,5 +1,6 @@
 #include "communicator.h"
 #include "task_set.h"
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/util/basic_types.cxx
+++ b/src/util/basic_types.cxx
@@ -35,6 +35,7 @@ void tblis_init_tensor_scaled_s(tblis_tensor* t, float scalar,
                                 stride_type* stride)
 {
     t->type = TYPE_SINGLE;
+    t->scalar.type = TYPE_SINGLE;
     t->conj = 0;
     t->scalar.data.s = scalar;
     t->data = data;
@@ -48,6 +49,7 @@ void tblis_init_tensor_scaled_d(tblis_tensor* t, double scalar,
                                 stride_type* stride)
 {
     t->type = TYPE_DOUBLE;
+    t->scalar.type = TYPE_DOUBLE;
     t->conj = 0;
     t->scalar.data.d = scalar;
     t->data = data;
@@ -61,6 +63,7 @@ void tblis_init_tensor_scaled_c(tblis_tensor* t, scomplex scalar,
                                 stride_type* stride)
 {
     t->type = TYPE_SCOMPLEX;
+    t->scalar.type = TYPE_SCOMPLEX;
     t->conj = 0;
     t->scalar.data.c = scalar;
     t->data = data;
@@ -74,6 +77,7 @@ void tblis_init_tensor_scaled_z(tblis_tensor* t, dcomplex scalar,
                                 stride_type* stride)
 {
     t->type = TYPE_DCOMPLEX;
+    t->scalar.type = TYPE_DCOMPLEX;
     t->conj = 0;
     t->scalar.data.z = scalar;
     t->data = data;

--- a/src/util/cpuid.cxx
+++ b/src/util/cpuid.cxx
@@ -206,50 +206,64 @@ namespace tblis
 
 int get_cpu_type(int& model, int& part, int& features)
 {
+    uint64_t midr_el1 = 0, implementer;
     model = MODEL_UNKNOWN;
     features = 0;
 
-    FILE *fd1 = popen("grep -m 1 Processor /proc/cpuinfo", "r");
-    if (!fd1) return VENDOR_ARM;
-    FILE *fd2 = popen("grep -m 1 'CPU part' /proc/cpuinfo", "r");
-    if (!fd2)
+#if !defined(__aarch64__)
+    // Armv7. Return early.
+    // NOTE: For ARM, It's common for /proc/cpuinfo to
+    //       not contain vendor name or arch name at all.
+    model = MODEL_ARMV7;
+    return VENDOR_UNKNOWN;
+#endif
+    // Armv8. Look into more details.
+    model = MODEL_ARMV8;
+
+#if defined(__APPLE__)
+    // Simple workaround for Apple Silicon.
+    features |= FEATURE_NEON;
+    return VENDOR_APPLE;
+#endif
+
+    FILE *fid = popen("grep -m 1 Features /proc/cpuinfo", "r");
+    if (fid)
     {
-        pclose(fd1);
-        return VENDOR_ARM;
+        char c;
+        std::string feat;
+        while ((c = fgetc(fid)) != EOF)
+            feat.push_back(c);
+        pclose(fid);
+
+        if (feat.find("neon") != std::string::npos ||
+            feat.find("asimd") != std::string::npos)
+            features |= FEATURE_NEON;
+        if (feat.find("sve") != std::string::npos)
+            features |= FEATURE_SVE;
     }
-    FILE *fd3 = popen("grep -m 1 Features /proc/cpuinfo", "r");
-    if (!fd3)
+
+    // https://github.com/flame/blis/pull/344
+    __asm__ ("mrs %0, MIDR_EL1" : "=r" (midr_el1));
+    implementer = (midr_el1 >> 24) & 0xFF;
+    part        = (midr_el1 >> 4)  & 0xFFF;
+
+    switch (implementer)
     {
-        pclose(fd1);
-        pclose(fd2);
-        return VENDOR_ARM;
+        case VENDOR_ARM:
+        case VENDOR_BROADCOM:
+        case VENDOR_CAVIUM:
+        case VENDOR_DEC:
+        case VENDOR_FUJITSU:
+        case VENDOR_NVIDIA:
+        case VENDOR_APM:
+        case VENDOR_QUALCOMM:
+        case VENDOR_SAMSUNG:
+        case VENDOR_TEXAS:
+        case VENDOR_MARVELL:
+            return implementer;
+        default:
+            return VENDOR_UNKNOWN;
     }
-
-    char c;
-    std::string proc, ptno, feat;
-    while ((c = fgetc(fd1)) != EOF) proc.push_back(c);
-    while ((c = fgetc(fd2)) != EOF) ptno.push_back(c);
-    while ((c = fgetc(fd3)) != EOF) feat.push_back(c);
-
-    pclose(fd1);
-    pclose(fd2);
-    pclose(fd3);
-
-    if (feat.find("neon") != std::string::npos ||
-        feat.find("asimd") != std::string::npos)
-        features |= FEATURE_NEON;
-
-    if (proc.find("ARMv7") != std::string::npos)
-        model = MODEL_ARMV7;
-    else if (proc.find("AArch64") != std::string::npos)
-        model = MODEL_ARMV8;
-
-    char *epos;
-    auto pos = ptno.find("0x");
-    TBLIS_ASSERT(pos != std::string::npos);
-    part = strtol(ptno.c_str() + pos, &epos, 16);
-
-    return VENDOR_ARM;
 }
 
 }

--- a/src/util/cpuid.cxx
+++ b/src/util/cpuid.cxx
@@ -244,9 +244,10 @@ int get_cpu_type(int& model, int& part, int& features)
     else if (proc.find("AArch64") != std::string::npos)
         model = MODEL_ARMV8;
 
+    char *epos;
     auto pos = ptno.find("0x");
     TBLIS_ASSERT(pos != std::string::npos);
-    part = strtoi(ptno, pos, 16);
+    part = strtol(ptno.c_str() + pos, &epos, 16);
 
     return VENDOR_ARM;
 }

--- a/src/util/cpuid.hpp
+++ b/src/util/cpuid.hpp
@@ -42,8 +42,8 @@ int get_cpu_type(int& family, int& model, int& features);
 namespace tblis
 {
 
-enum {VENDOR_ARM, VENDOR_UNKNOWN}
-enum {MODEL_ARMV7, MODEL_ARMV8, MODEL_UNKNOWN}
+enum {VENDOR_ARM, VENDOR_UNKNOWN};
+enum {MODEL_ARMV7, MODEL_ARMV8, MODEL_UNKNOWN};
 enum {FEATURE_NEON = 0x1};
 
 int get_cpu_type(int& model, int& part, int& features);

--- a/src/util/cpuid.hpp
+++ b/src/util/cpuid.hpp
@@ -42,9 +42,21 @@ int get_cpu_type(int& family, int& model, int& features);
 namespace tblis
 {
 
-enum {VENDOR_ARM, VENDOR_UNKNOWN};
+enum {VENDOR_ARM      = 0x41,
+      VENDOR_BROADCOM = 0x42,
+      VENDOR_CAVIUM   = 0x43,
+      VENDOR_DEC      = 0x44,
+      VENDOR_FUJITSU  = 0x45,
+      VENDOR_NVIDIA   = 0x4e,
+      VENDOR_APM      = 0x50,
+      VENDOR_QUALCOMM = 0x51,
+      VENDOR_SAMSUNG  = 0x53,
+      VENDOR_TEXAS    = 0x54,
+      VENDOR_MARVELL  = 0x56,
+      VENDOR_UNKNOWN  = 0x00,
+      VENDOR_APPLE    = 0xff}; // Apple does not have /proc/cpuinfo.
 enum {MODEL_ARMV7, MODEL_ARMV8, MODEL_UNKNOWN};
-enum {FEATURE_NEON = 0x1};
+enum {FEATURE_NEON, FEATURE_SVE};
 
 int get_cpu_type(int& model, int& part, int& features);
 


### PR DESCRIPTION
- [x] Arm64 (Cortex-A53 or higher, ThunderX2, etc.)
- [x] Arm32 (Cortex-A9, Cortex-A15, etc.)
- [ ] Arm64+SVE (A64fx, Neoverse, etc.)

## Comments

- flame/blis#344 way of determining Arm64 implementation is adopted here.
- I'm creating configs `armv7a` and `armv8a` because config `cortexa53` is roughly the same as `cortexa57` in BLIS config (similarly: `cortexa9` is close to `cortexa15`). So is it good to now remove `cortex-a9` and `cortex-a15` lines in `configure.ac`? Or should I rename current `armv8a` to `cortexa53` to reproduce the current BLIS layout?