### PR TITLE
Detect gcc even if compiler binary is symlinked

### DIFF
--- a/configure
+++ b/configure
@@ -6706,8 +6706,8 @@ if test x"$vendor_string" = x; then
     as_fn_error $? "Unable to determine compiler vendor." "$LINENO" 5
 fi
 
-cc_vendor=`echo $vendor_string | $EGREP -oi 'icc|gcc|clang|emcc|pnacl|IBM|gnu-cc' | tr 'A-Z' 'a-z' | { read first rest ; echo $first ; }`
-if test x"$cc_vendor" = "xgnu-cc"; then
+cc_vendor=`echo $vendor_string | $EGREP -oi 'icc|gcc|clang|emcc|pnacl|IBM|gnu-cc|Free Software Foundation' | tr 'A-Z' 'a-z' | { read first rest ; echo $first ; }`
+if test x"$cc_vendor" = "xgnu-cc" || test x"$cc_vendor" = "xfree"; then
     cc_vendor=gcc
 fi
 if test x"$cc_vendor" = x; then
@@ -21261,5 +21261,3 @@ printf "%s\n" "$as_me: running $SHELL $ac_sub_configure $ac_sub_configure_args -
     cd "$ac_popdir"
   done
 fi
-
-


### PR DESCRIPTION
Sometimes the compiler identification (the only part that `configure` currently uses to detect the vendor) is derived from the running executable name (`argv[0]`):

```
computelab-frontend-2:~> /usr/bin/cc --version
cc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
computelab-frontend-2:~> file /usr/bin/cc
/usr/bin/cc: symbolic link to /etc/alternatives/cc
computelab-frontend-2:~> file /etc/alternatives/cc
/etc/alternatives/cc: symbolic link to /usr/bin/gcc
computelab-frontend-2:~> file /usr/bin/gcc
/usr/bin/gcc: symbolic link to gcc-7
computelab-frontend-2:~> file /usr/bin/gcc-7
/usr/bin/gcc-7: symbolic link to x86_64-linux-gnu-gcc-7
computelab-frontend-2:~> file /usr/bin/x86_64-linux-gnu-gcc-7
/usr/bin/x86_64-linux-gnu-gcc-7: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=ed689667cbe4853eab660ee39815f2938720fdfc, stripped
computelab-frontend-2:~> /usr/bin/x86_64-linux-gnu-gcc-7 --version
x86_64-linux-gnu-gcc-7 (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Following the symlinks until an actual binary could be an option, but then we would need to only do this for vendor identification, and use the original symlink for actual compilation. And that's because certain vendors (e.g. Apple, HPE Cray) depend on the symlink being used, and don't allow / won't work properly if the underlying executable is used.

This change sidesteps this whole issue (at least for gcc), by looking for the string "Free Software Foundation", which should be unique among compiler version messages.