### PR TITLE
fix check for OpenMP SIMD pragma

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,7 @@ AM_CONDITIONAL(IS_OSX, [test `uname -s` = Darwin])
 #
 
 AC_MSG_CHECKING([for OpenMP SIMD pragma])
+AC_LANG_PUSH([C++])
 omp_simd_flag="not supported"
 for flag in -fopenmp-simd -qopenmp-simd; do
     CXXFLAGS_save="$CXXFLAGS"
@@ -58,6 +59,7 @@ for flag in -fopenmp-simd -qopenmp-simd; do
         ]])],[omp_simd_flag="$flag"],[])
     CXXFLAGS="$CXXFLAGS_save"
 done
+AC_LANG_POP([C++])
 AC_MSG_RESULT([$omp_simd_flag])
 if test "x$omp_simd_flag" != "xnot supported"; then
     CXXFLAGS="$CXXFLAGS $omp_simd_flag"


### PR DESCRIPTION
During configuration, I got an unexpected message:
```checking for OpenMP SIMD pragma... not supported
```

config.log says

```
configure:6528: checking for OpenMP SIMD pragma
configure:6551: gcc -c -O3  conftest.c >&5
conftest.c:14:10: fatal error: cstdio: No such file or directory
   14 | #include <cstdio>
      |          ^~~~~~~~
compilation terminated.
...
```

Setting the language to C++ (temporarily) seems to fix this. What do you think?