### PR TITLE
adding fixes to compile on arm-based macs (osx 15+)

### DIFF
--- a/src/external/marray/include/expression.hpp
+++ b/src/external/marray/include/expression.hpp
@@ -1,7 +1,9 @@
 #ifndef _MARRAY_EXPRESSION_HPP_
 #define _MARRAY_EXPRESSION_HPP_
 
+#if defined (__x86_64__)
 #include <x86intrin.h>
+#endif
 
 #include "utility.hpp"
 #include "vector.hpp"

--- a/src/external/tci/tci/task_set.c
+++ b/src/external/tci/tci/task_set.c
@@ -1,5 +1,8 @@
 #include "communicator.h"
 #include "task_set.h"
+#if !defined(_GLIBCXX_STDLIB_H)
+#include <stdlib.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/util/cpuid.cxx
+++ b/src/util/cpuid.cxx
@@ -246,7 +246,11 @@ int get_cpu_type(int& model, int& part, int& features)
 
     auto pos = ptno.find("0x");
     TBLIS_ASSERT(pos != std::string::npos);
+#if defined(__APPLE__) && defined(__MACH__)
+      part = (int)strtol(ptno.c_str(), (char**)pos, 16);
+#else
     part = strtoi(ptno, pos, 16);
+#endif
 
     return VENDOR_ARM;
 }

--- a/src/util/cpuid.hpp
+++ b/src/util/cpuid.hpp
@@ -42,8 +42,8 @@ int get_cpu_type(int& family, int& model, int& features);
 namespace tblis
 {
 
-enum {VENDOR_ARM, VENDOR_UNKNOWN}
-enum {MODEL_ARMV7, MODEL_ARMV8, MODEL_UNKNOWN}
+enum {VENDOR_ARM, VENDOR_UNKNOWN};
+enum {MODEL_ARMV7, MODEL_ARMV8, MODEL_UNKNOWN};
 enum {FEATURE_NEON = 0x1};
 
 int get_cpu_type(int& model, int& part, int& features);


### PR DESCRIPTION
this pr proposes a few (minor) fixes for the compilation of tblis on arm-based mac osx. 

apart from issues with includes and small syntax errors, replaced strtoi() by strtol() since the former is not available (though strtoimax() is).

the code has been tested (all tests passed) with gcc-14 on an arm/mac osx system and on linux.