### PR TITLE
a handful of minor bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,9 @@ option(ENABLE_STATIC "Build a static library" ON)
 option(ENABLE_COMPAT "Enable compatibility with the TBLIS 1.x interface" OFF)
 set(TBLIS_ENABLE_COMPAT ${ENABLE_COMPAT})
 
-option(ENABLE_MEMKIND OFF "Enable use of the memkind library for MCDRAM allocation if supported.")
+option(ENABLE_MEMKIND "Enable use of the memkind library for MCDRAM allocation if supported." OFF)
 
-option(ENABLE_HWLOC ON "Enable use of the memkind library for MCDRAM allocation if supported.")
+option(ENABLE_HWLOC "Enable use of the hwloc library for hardware locality awareness." ON)
 
 set(BLIS_CONFIG_FAMILY auto CACHE STRING "BLIS sub-configuration to use.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ option(ENABLE_HWLOC "Enable use of the hwloc library for hardware locality aware
 
 set(BLIS_CONFIG_FAMILY auto CACHE STRING "BLIS sub-configuration to use.")
 
+set(BLIS_THREAD_MODEL pthread CACHE STRING "BLIS threading model to use.")
+
 set(LENGTH_TYPE ptrdiff_t CACHE STRING "The type to use for lengths of tensor dimensions. Must be a signed ISO C integer type.")
 
 set(STRIDE_TYPE ptrdiff_t CACHE STRING "The type to use for strides of tensor dimensions. Must be a signed ISO C integer type.")
@@ -354,7 +356,7 @@ else()
                 ${BLIS_DEBUG_FLAG}
                 --disable-blas
                 --disable-cblas
-                "--enable-threading=pthread"
+                "--enable-threading=${BLIS_THREAD_MODEL}"
                 ${BLIS_CONFIG_FAMILY}
         )
         file(MAKE_DIRECTORY ${BLIS_INSTALL_DIR}/include/blis)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,11 +360,23 @@ else()
         file(MAKE_DIRECTORY ${BLIS_INSTALL_DIR}/include/blis)
     endif()
 
+    # Add + to the Make recipe line if CMake is new enough.
+    # This enables parallel compilation of the plugin.
+    # It does nothing if the generator isn't Make.
+    # Tested with CMake<3.28 and >=3.28
+    # See the CMake documentation for "add_custom_command"
+    # (Since you need Make anyway, it's a good idea to use it as the generator.)
+    set(TBLIS_JOBSERVER_AWARE_ARG "")
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.28.0")
+      set(TBLIS_JOBSERVER_AWARE_ARG JOB_SERVER_AWARE TRUE)
+    endif()
+
     add_custom_command(
         COMMAND ${MAKE_EXECUTABLE} install
         OUTPUT
             ${BLIS_INSTALL_DIR}/lib/libblis.a
             ${BLIS_INSTALL_DIR}/include/blis/blis.h
+        ${TBLIS_JOBSERVER_AWARE_ARG}
         COMMENT "Building BLIS"
         WORKING_DIRECTORY ${BLIS_BINARY_DIR}
     )
@@ -449,6 +461,7 @@ add_custom_target(plugin-configure
 add_custom_command(
     OUTPUT ${TBLIS_PLUGIN_DIR}/lib/${BLIS_CONFIG_FAMILY}/libblis_tblis.a
     COMMAND ${MAKE_EXECUTABLE}
+    ${TBLIS_JOBSERVER_AWARE_ARG}
     DEPENDS plugin-configure
     COMMENT "Building BLIS plugin"
     WORKING_DIRECTORY ${TBLIS_PLUGIN_DIR}


### PR DESCRIPTION
1. I added `JOB_SERVER_AWARE TRUE` to the BLIS and plugin `add_custom_command`s if CMake is new enough. This lets the plugin compile in parallel. BLIS already compiles in parallel; I'm not sure why.

2. I also fixed
```diff
-option(ENABLE_MEMKIND OFF "Enable use of the memkind library for MCDRAM allocation if supported.")
+option(ENABLE_MEMKIND "Enable use of the memkind library for MCDRAM allocation if supported." OFF)
 
-option(ENABLE_HWLOC ON "Enable use of the memkind library for MCDRAM allocation if supported.")
+option(ENABLE_HWLOC "Enable use of the hwloc library for hardware locality awareness." ON)
```
which effectively caused ENABLE_HWLOC to be turned off by default.

3. Thread configuration constructor prints how num threads is calculated, if you set `TBLIS_VERBOSE=1`
4. Fix lscpu arithmetic (#70)
5. hwloc discovers num cores as `num_threads = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE);` rather than the number of L1 caches
6. an option (cmake: `-DBLIS_THREAD_MODEL`, configure: `--with-blis-thread-model`) for specifying BLIS thread model. Otherwise, if TBLIS uses openmp and BLIS uses pthreads, then openmp thread affinity causes all BLIS threads to be pinned to the core of the omp master thread